### PR TITLE
Simplified Logging + Log Level Environment Variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs/html
 /.settings/language.settings.xml
 /sh.exe.stackdump
 /asn1c_combined/J2735_201603DA.ASN
+
+.env

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -43,6 +43,7 @@ ADD ./include /asn1_codec/include
 ADD ./src /asn1_codec/src
 ADD ./kafka-test /asn1_codec/kafka-test
 ADD ./unit-test-data /asn1_codec/unit-test-data
+ADD ./run_acm.sh /asn1_codec
 
 # Build acm.
 RUN mkdir -p /build && cd /build && cmake /asn1_codec && make

--- a/docker-compose-confluent-cloud.yml
+++ b/docker-compose-confluent-cloud.yml
@@ -7,11 +7,12 @@ services:
     environment:
       DOCKER_HOST_IP: ${DOCKER_HOST_IP}
       KAFKA_TYPE: ${KAFKA_TYPE}
-      CONFLUENT_KEY: ${CONFLUENT_KEY}
-      CONFLUENT_SECRET: ${CONFLUENT_SECRET}
       ACM_CONFIG_FILE: adm.properties
       ACM_LOG_TO_CONSOLE: "true"
       ACM_LOG_TO_FILE: "false"
+      ACM_LOG_LEVEL: ${ACM_LOG_LEVEL}
+      CONFLUENT_KEY: ${CONFLUENT_KEY}
+      CONFLUENT_SECRET: ${CONFLUENT_SECRET}
   aem:
     build:
       context: .
@@ -19,8 +20,9 @@ services:
     environment:
       DOCKER_HOST_IP: ${DOCKER_HOST_IP}
       KAFKA_TYPE: ${KAFKA_TYPE}
-      CONFLUENT_KEY: ${CONFLUENT_KEY}
-      CONFLUENT_SECRET: ${CONFLUENT_SECRET}
       ACM_CONFIG_FILE: aem.properties
       ACM_LOG_TO_CONSOLE: "true"
       ACM_LOG_TO_FILE: "false"
+      ACM_LOG_LEVEL: ${ACM_LOG_LEVEL}
+      CONFLUENT_KEY: ${CONFLUENT_KEY}
+      CONFLUENT_SECRET: ${CONFLUENT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,3 +31,4 @@ services:
       ACM_CONFIG_FILE: adm.properties
       ACM_LOG_TO_CONSOLE: "true"
       ACM_LOG_TO_FILE: "false"
+      ACM_LOG_LEVEL: ${ACM_LOG_LEVEL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   asn1_codec:
     build:
       context: .
-      dockerfile: Dockerfile.standalone
+      dockerfile: Dockerfile
     ports:
       - "8080:8080"
       - "9090:9090"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,8 +25,7 @@ line options override parameters specified in the configuration file.** The foll
 ```bash
 -T | --codec-type      : The type of codec to use: decode or encode; defaults to decode
 -h | --help            : print out some help
--e | --elog            : Error log file name.
--i | --ilog            : Information log file name.
+-i | --log             : Log file name.
 -R | --log-rm          : Remove specified/default log files if they exist.
 -D | --log-dir         : Directory for the log files.
 -F | --infile          : accept a file and bypass kafka.
@@ -103,24 +102,22 @@ handle multiple partitions within a single topic.
 
 # ACM Logging
 
-ACM operations are logged to two files: an information log and an error log.  The files are rotating log files, i.e., a set number of log files will
-be used to record the ACM's information. By default, these files are located in a `logs` directory from where the ACM is launched and the files are
-named `log.info` and `log.error`. The maximum size of a `log.info` files is 5MB and 5 files are rotated. The maximum size of a `log.error` file is 2MB
-and 2 files are rotated. Logging configuration is controlled through the command line, not through the configuration file. The following operation are available:
+ACM operations are optionally logged to the console and/or to a file.  The file is a rotating log file, i.e., a set number of log files will
+be used to record the ACM's information. By default, the file is in a `logs` directory from where the ACM is launched and the file is
+named `log`. The maximum size of a `log` file is 5MB and 5 files are rotated.
+Logging configuration is controlled through the command line, not through the configuration file. The following operation are available:
 
 - `-R` : When the ACM starts remove any log files having either the default or user specified names; otherwise, new log entries will be appended to existing files.
 
 - `-D` : The directory where the log files should be written. This can be relative or absolute. If the directory does not exist, it will be created.
 
-- `-e` : The error log file's name.
+- `-i` : The log file's name.
 
-- `-i` : The information log file's name.
-
-- `-v` : The minimum level of message to write to the information log. From lowest to highest, the message levels are `off`, `trace`, `debug`, `info`,
+- `-v` : The minimum level of message to write to the log. From lowest to highest, the message levels are `off`, `trace`, `debug`, `info`,
          `warning`, `error`, `critical`. As an example, if you specify `info` then all messages that are `info, warning, error, or critical` will be written to
          the log.
 
-The information log will write the configuration it will use as `info` messages when it starts.  All log messages are
+The log will write the configuration it will use as `info` messages when it starts.  All log messages are
 preceeded with a date and time stamp and the level of the log message.
 
 ```

--- a/include/acm.hpp
+++ b/include/acm.hpp
@@ -238,10 +238,6 @@ class ASN1_Codec : public tool::Tool {
         static bool bootstrap;                                          ///> flag indicating we need to bootstrap the consumer and producer
         static bool data_available;                                     ///> flag to exit application; set via signals so static.
 
-        static constexpr long ilogsize = 1048576 * 5;                   ///> The size of a single information log; these rotate.
-        static constexpr long elogsize = 1048576 * 2;                   ///> The size of a single error log; these rotate.
-        static constexpr int ilognum = 5;                               ///> The number of information logs to rotate.
-        static constexpr int elognum = 2;                               ///> The number of error logs to rotate.
         static constexpr std::size_t max_errbuf_size = 128;             ///> The length of error buffers for ASN.1 compiler.
 
         // possible encoding configurations.
@@ -266,8 +262,6 @@ class ASN1_Codec : public tool::Tool {
         uint64_t msg_filt_bytes;                                        ///> Counter for the nubmer of BSM bytes filtered/suppressed.
 
         // Logging.
-        spdlog::level::level_enum iloglevel;                            ///> Log level for the information log.
-        spdlog::level::level_enum eloglevel;                            ///> Log level for the error log.
         std::string mode;
         std::string debug;
 

--- a/include/acmLogger.hpp
+++ b/include/acmLogger.hpp
@@ -12,12 +12,10 @@
  */
 class AcmLogger {
     public:
-        AcmLogger(std::string ilogname, std::string elogname);
+        AcmLogger(std::string logname);
 
-        void set_info_level(spdlog::level::level_enum level);
-        void set_error_level(spdlog::level::level_enum level);
-        void set_info_pattern(const std::string& pattern);
-        void set_error_pattern(const std::string& pattern);
+        void set_level(spdlog::level::level_enum level);
+        void set_pattern(const std::string& pattern);
         
         void info(const std::string& message);
         void error(const std::string& message);
@@ -28,22 +26,17 @@ class AcmLogger {
         void flush();
 
     private:
-        long INFO_LOG_SIZE = 1048576 * 5;                   ///> The size of a single information log; these rotate.
-        long ERROR_LOG_SIZE = 1048576 * 2;                   ///> The size of a single error log; these rotate.
-        int INFO_LOG_NUM = 5;                               ///> The number of information logs to rotate.
-        int ERROR_LOG_NUM = 2;                               ///> The number of error logs to rotate.
+        long LOG_SIZE = 1048576 * 5;                   ///> The size of a single log; these rotate.
+        int LOG_NUM = 5;                               ///> The number of logs to rotate.
     
-        spdlog::level::level_enum iloglevel = spdlog::level::trace;     ///> Log level for the information log.
-        spdlog::level::level_enum eloglevel = spdlog::level::err;       ///> Log level for the error log.
+        spdlog::level::level_enum loglevel = spdlog::level::trace;     ///> Log level for the logger.
         
-        std::shared_ptr<spdlog::logger> ilogger;
-        std::shared_ptr<spdlog::logger> elogger;
+        std::shared_ptr<spdlog::logger> spdlogger;     ///> The spdlog logger.
 
         bool logToFileFlag;
         bool logToConsoleFlag;
 
-        void setInfoLogger(std::shared_ptr<spdlog::logger> spdlog_logger);
-        void setErrorLogger(std::shared_ptr<spdlog::logger> spdlog_logger);
+        void setLogger(std::shared_ptr<spdlog::logger> spdlog_logger);
         void initializeFlagValuesFromEnvironment();
         const char* getEnvironmentVariable(std::string var);
         std::string toLowercase(std::string str);

--- a/include/acm_blob_producer.hpp
+++ b/include/acm_blob_producer.hpp
@@ -86,24 +86,16 @@ class ACMBlobProducer : public tool::Tool {
     private:
 
         static bool data_available;                                     ///> flag to exit application; set via signals so static.
-
-        static constexpr long ilogsize = 1048576 * 5;                   ///> The size of a single information log; these rotate.
-        static constexpr long elogsize = 1048576 * 2;                   ///> The size of a single error log; these rotate.
         
         // If this buffer size is too small then an entire record will not be processed and things will FAIL!
         // buffer for the ASN1 stuff.
         static constexpr std::size_t BUFSIZE = 1<<12;                   ///> 4k
         uint8_t buf[BUFSIZE];
 
-        static constexpr int ilognum = 5;                               ///> The number of information logs to rotate.
-        static constexpr int elognum = 2;                               ///> The number of error logs to rotate.
-
         // counters.
         uint64_t msg_send_count;                                            ///> Counter for the number of BSMs published.
-        uint64_t msg_send_bytes;                                         ///> Counter for the nubmer of BSM bytes published.
-
-        spdlog::level::level_enum iloglevel;                            ///> Log level for the information log.
-        spdlog::level::level_enum eloglevel;                            ///> Log level for the error log.
+        uint64_t msg_send_bytes;                                         ///> Counter for the number of BSM bytes published.
+        
         std::string debug;
         std::string input_file;
         std::size_t block_size;

--- a/run_acm.sh
+++ b/run_acm.sh
@@ -2,4 +2,4 @@
 export LD_LIBRARY_PATH=/usr/local/lib
 
 # Start the ACM
-/build/acm -c /asn1_codec/config/${ACM_CONFIG_FILE} -b ${DOCKER_HOST_IP}:9092 -R
+/build/acm -c /asn1_codec/config/${ACM_CONFIG_FILE} -b ${DOCKER_HOST_IP}:9092 -v ${ACM_LOG_LEVEL} -R

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,11 @@
+# The IP address of the machine running the kafka cluster.
+DOCKER_HOST_IP=
+
+# Whether or not to log to the console.
+ACM_LOG_TO_CONSOLE=
+
+# Whether or not to log to a file.
+ACM_LOG_TO_FILE=
+
+# The log level to use.
+ACM_LOG_LEVEL=

--- a/sample.env
+++ b/sample.env
@@ -8,4 +8,5 @@ ACM_LOG_TO_CONSOLE=
 ACM_LOG_TO_FILE=
 
 # The log level to use.
+# Valid values are: "debug", "info", "warning", "error", "critical", "off"
 ACM_LOG_LEVEL=

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -171,8 +171,6 @@ ASN1_Codec::ASN1_Codec( const std::string& name, const std::string& description 
     , msg_recv_bytes{0}
     , msg_send_bytes{0}
     , msg_filt_bytes{0}
-    , iloglevel{ spdlog::level::trace }
-    , eloglevel{ spdlog::level::err }
     , pconf{}
     , brokers{"localhost"}
     , partition{RdKafka::Topic::PARTITION_UA}
@@ -1906,8 +1904,7 @@ int main( int argc, char* argv[] )
     asn1_codec.addOption( 'v', "log-level", "The info log level [trace,debug,info,warning,error,critical,off]", true );
     asn1_codec.addOption( 'D', "log-dir", "Directory for the log files.", true );
     asn1_codec.addOption( 'R', "log-rm", "Remove specified/default log files if they exist.", false );
-    asn1_codec.addOption( 'i', "ilog", "Information log file name.", true );
-    asn1_codec.addOption( 'e', "elog", "Error log file name.", true );
+    asn1_codec.addOption( 'i', "log", "Log file name.", true );
     asn1_codec.addOption( 'h', "help", "print out some help" );
     asn1_codec.addOption( 'F', "infile", "accept a file and bypass kafka.", false );
     asn1_codec.addOption( 'T', "codec-type", "The type of codec to use: decode or encode; defaults to decode", true );

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -425,21 +425,21 @@ bool ASN1_Codec::configure() {
         else if ( "decode" == optString('T') ) decode_functionality = true;
     } 
     
-    if ( optIsSet('v') ) {
-        if ( "trace" == optString('v') ) {
-            logger->set_info_level( spdlog::level::trace );
-        } else if ( "debug" == optString('v') ) {
-            logger->set_info_level( spdlog::level::trace );
-        } else if ( "info" == optString('v') ) {
-            logger->set_info_level( spdlog::level::trace );
-        } else if ( "warning" == optString('v') ) {
-            logger->set_info_level( spdlog::level::warn );
-        } else if ( "error" == optString('v') ) {
-            logger->set_info_level( spdlog::level::err );
-        } else if ( "critical" == optString('v') ) {
-            logger->set_info_level( spdlog::level::critical );
-        } else if ( "off" == optString('v') ) {
-            logger->set_info_level( spdlog::level::off );
+    if (optIsSet('v')) {
+        if ("trace" == optString('v')) {
+            logger->set_level(spdlog::level::trace);
+        } else if ("debug" == optString('v')) {
+            logger->set_level(spdlog::level::trace);
+        } else if ("info" == optString('v')) {
+            logger->set_level(spdlog::level::trace);
+        } else if ("warning" == optString('v')) {
+            logger->set_level(spdlog::level::warn);
+        } else if ("error" == optString('v')) {
+            logger->set_level(spdlog::level::err);
+        } else if ("critical" == optString('v')) {
+            logger->set_level(spdlog::level::critical);
+        } else if ("off" == optString('v')) {
+            logger->set_level(spdlog::level::off);
         } else {
             logger->warn("information logger level was configured but unreadable; using default.");
         }
@@ -645,8 +645,7 @@ bool ASN1_Codec::launch_consumer(){
 bool ASN1_Codec::make_loggers( bool remove_files ) {    
     // defaults.
     std::string path{ "logs/" };
-    std::string ilogname{ "log.info" };
-    std::string elogname{ "log.error" };
+    std::string logname{ "log.info" };
 
     if (getOption('D').hasArg()) {
         // replace default
@@ -671,36 +670,23 @@ bool ASN1_Codec::make_loggers( bool remove_files ) {
         }
     }
     
-    // ilog check for user-defined file locations and names.
+    // log check for user-defined file locations and names.
     if (getOption('i').hasArg()) {
         // replace default.
-        ilogname = string_utilities::basename<std::string>( getOption('i').argument() );
-    }
-
-    if (getOption('e').hasArg()) {
-        // replace default.
-        elogname = string_utilities::basename<std::string>( getOption('e').argument() );
+        logname = string_utilities::basename<std::string>( getOption('i').argument() );
     }
     
-    ilogname = path + ilogname;
-    elogname = path + elogname;
+    logname = path + logname;
 
-    if ( remove_files && fileExists( ilogname ) ) {
-        if ( std::remove( ilogname.c_str() ) != 0 ) {
+    if ( remove_files && fileExists( logname ) ) {
+        if ( std::remove( logname.c_str() ) != 0 ) {
             std::cerr << "Error removing the previous information log file.\n";
             return false;
         }
     }
 
-    if ( remove_files && fileExists( elogname ) ) {
-        if ( std::remove( elogname.c_str() ) != 0 ) {
-            std::cerr << "Error removing the previous error log file.\n";
-            return false;
-        }
-    }
-
     // initialize logger
-    logger = std::make_shared<AcmLogger>(ilogname, elogname);
+    logger = std::make_shared<AcmLogger>(logname);
     return true;
 }
 

--- a/src/acmLogger.cpp
+++ b/src/acmLogger.cpp
@@ -1,81 +1,56 @@
 #include "../include/acmLogger.hpp"
 
-AcmLogger::AcmLogger(std::string ilogname, std::string elogname) {
+AcmLogger::AcmLogger(std::string logname) {
     // pull in the file & console flags from the environment
     initializeFlagValuesFromEnvironment();
     
-    // setup information logger.
-    std::vector<spdlog::sink_ptr> infoSinks;
+    // setup spdlogger logger.
+    std::vector<spdlog::sink_ptr> sinks;
     if (logToFileFlag) {
-        infoSinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(ilogname, INFO_LOG_SIZE, INFO_LOG_NUM));
+        sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logname, LOG_SIZE, LOG_NUM));
     }
     if (logToConsoleFlag) {
-        infoSinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
+        sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
     }
-    setInfoLogger(std::make_shared<spdlog::logger>("ilog", begin(infoSinks), end(infoSinks)));
-    set_info_level( iloglevel );
-    set_info_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
-
-    // setup error logger.
-    std::vector<spdlog::sink_ptr> errorSinks;
-    if (logToFileFlag) {
-        errorSinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(elogname, ERROR_LOG_SIZE, ERROR_LOG_NUM));
-    }
-    if (logToConsoleFlag) {
-        errorSinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
-    }
-    setErrorLogger(std::make_shared<spdlog::logger>("elog", begin(errorSinks), end(errorSinks)));
-    set_error_level( eloglevel );
-    set_error_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
+    setLogger(std::make_shared<spdlog::logger>("ilog", begin(sinks), end(sinks)));
+    set_level(loglevel);
+    set_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
 }
 
-void AcmLogger::set_info_level(spdlog::level::level_enum level) {
-    ilogger->set_level( level );
+void AcmLogger::set_level(spdlog::level::level_enum level) {
+    spdlogger->set_level(level);
 }
 
-void AcmLogger::set_error_level(spdlog::level::level_enum level) {
-    elogger->set_level( level );
-}
-
-void AcmLogger::set_info_pattern(const std::string& pattern) {
-    ilogger->set_pattern( pattern );
-}
-
-void AcmLogger::set_error_pattern(const std::string& pattern) {
-    elogger->set_pattern( pattern );
+void AcmLogger::set_pattern(const std::string& pattern) {
+    spdlogger->set_pattern(pattern);
 }
 
 void AcmLogger::info(const std::string& message) {
-    ilogger->info(message.c_str());
+    spdlogger->info(message.c_str());
 }
 
 void AcmLogger::error(const std::string& message) {
-    elogger->error(message.c_str());
+    spdlogger->error(message.c_str());
 }
 
 void AcmLogger::trace(const std::string& message) {
-    ilogger->trace(message.c_str());
+    spdlogger->trace(message.c_str());
 }
 
 void AcmLogger::critical(const std::string& message) {
-    elogger->critical(message.c_str());
+    spdlogger->critical(message.c_str());
 }
 
 void AcmLogger::warn(const std::string& message) {
-    elogger->warn(message.c_str());
+    spdlogger->warn(message.c_str());
 }
 
 void AcmLogger::flush() {
-    ilogger->flush();
-    elogger->flush();
+    spdlogger->flush();
 }
 
-void AcmLogger::setInfoLogger(std::shared_ptr<spdlog::logger> spdlog_logger) {
-    ilogger = spdlog_logger;
-}
-
-void AcmLogger::setErrorLogger(std::shared_ptr<spdlog::logger> spdlog_logger) {
-    elogger = spdlog_logger;
+void AcmLogger::setLogger(std::shared_ptr<spdlog::logger> spdlog_logger) {
+    spdlogger = spdlog_logger;
 }
 
 void AcmLogger::initializeFlagValuesFromEnvironment() {
@@ -85,7 +60,7 @@ void AcmLogger::initializeFlagValuesFromEnvironment() {
     logToConsoleFlag = convertStringToBool(logToConsoleFlagString);
 
     if (!logToFileFlag && !logToConsoleFlag) {
-        std::cout << "WARNING: ACM_LOG_TO_FILE and ACM_LOG_TO_CONSOLE are both set to false. No logging will occur." << std::endl;
+        std::cout << "WARNING: The ACM_LOG_TO_FILE and ACM_LOG_TO_CONSOLE environment variables are both set to false. No logging will occur." << std::endl;
     }
 }
 

--- a/src/acmLogger.cpp
+++ b/src/acmLogger.cpp
@@ -12,7 +12,7 @@ AcmLogger::AcmLogger(std::string logname) {
     if (logToConsoleFlag) {
         sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
     }
-    setLogger(std::make_shared<spdlog::logger>("ilog", begin(sinks), end(sinks)));
+    setLogger(std::make_shared<spdlog::logger>("log", begin(sinks), end(sinks)));
     set_level(loglevel);
     set_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
 }

--- a/src/acm_blob_producer.cpp
+++ b/src/acm_blob_producer.cpp
@@ -114,8 +114,6 @@ ACMBlobProducer::ACMBlobProducer( const std::string& name, const std::string& de
     Tool{ name, description },
     msg_send_count{0},
     msg_send_bytes{0},
-    iloglevel{ spdlog::level::trace },
-    eloglevel{ spdlog::level::err },
     mconf{},
     partition{RdKafka::Topic::PARTITION_UA},
     debug{""},
@@ -398,7 +396,7 @@ bool ACMBlobProducer::make_loggers( bool remove_files )
         }
     }
     
-    // ilog check for user-defined file locations and names.
+    // log check for user-defined file locations and names.
     if (getOption('i').hasArg()) {
         // replace default.
         logname = string_utilities::basename<std::string>( getOption('i').argument() );
@@ -513,8 +511,7 @@ int main(int argc, char* argv[])
     acm_blob_producer.addOption('v', "log-level", "The info log level [trace,debug,info,warning,error,critical,off]", true);
     acm_blob_producer.addOption('D', "log-dir", "Directory for the log files.", true);
     acm_blob_producer.addOption('R', "log-rm", "Remove specified/default log files if they exist.", false);
-    acm_blob_producer.addOption('i', "ilog", "Information log file name.", true);
-    acm_blob_producer.addOption('e', "elog", "Error log file name.", true);
+    acm_blob_producer.addOption('i', "log", "Log file name.", true);
     acm_blob_producer.addOption('F', "file", "Input binary file", true);
     acm_blob_producer.addOption('B', "blocksize", "The block size to read and write.", true);
     acm_blob_producer.addOption('h', "help", "print out some help");

--- a/src/acm_blob_producer.cpp
+++ b/src/acm_blob_producer.cpp
@@ -183,19 +183,19 @@ bool ACMBlobProducer::configure() {
 
     if ( optIsSet('v') ) {
         if ( "trace" == optString('v') ) {
-            logger->set_info_level( spdlog::level::trace );
+            logger->set_level( spdlog::level::trace );
         } else if ( "debug" == optString('v') ) {
-            logger->set_info_level( spdlog::level::trace );
+            logger->set_level( spdlog::level::trace );
         } else if ( "info" == optString('v') ) {
-            logger->set_info_level( spdlog::level::trace );
+            logger->set_level( spdlog::level::trace );
         } else if ( "warning" == optString('v') ) {
-            logger->set_info_level( spdlog::level::warn );
+            logger->set_level( spdlog::level::warn );
         } else if ( "error" == optString('v') ) {
-            logger->set_info_level( spdlog::level::err );
+            logger->set_level( spdlog::level::err );
         } else if ( "critical" == optString('v') ) {
-            logger->set_info_level( spdlog::level::critical );
+            logger->set_level( spdlog::level::critical );
         } else if ( "off" == optString('v') ) {
-            logger->set_info_level( spdlog::level::off );
+            logger->set_level( spdlog::level::off );
         } else {
             logger->warn("information logger level was configured but unreadable; using default.");
         }
@@ -373,8 +373,7 @@ bool ACMBlobProducer::make_loggers( bool remove_files )
 {
     // defaults.
     std::string path{ "logs/" };
-    std::string ilogname{ "log.bproducer.info" };
-    std::string elogname{ "log.bproducer.error" };
+    std::string logname{ "log.bproducer.info" };
 
     if (getOption('D').hasArg()) {
         // replace default
@@ -402,33 +401,20 @@ bool ACMBlobProducer::make_loggers( bool remove_files )
     // ilog check for user-defined file locations and names.
     if (getOption('i').hasArg()) {
         // replace default.
-        ilogname = string_utilities::basename<std::string>( getOption('i').argument() );
-    }
-
-    if (getOption('e').hasArg()) {
-        // replace default.
-        elogname = string_utilities::basename<std::string>( getOption('e').argument() );
+        logname = string_utilities::basename<std::string>( getOption('i').argument() );
     }
     
-    ilogname = path + ilogname;
-    elogname = path + elogname;
+    logname = path + logname;
 
-    if ( remove_files && fileExists( ilogname ) ) {
-        if ( std::remove( ilogname.c_str() ) != 0 ) {
+    if ( remove_files && fileExists( logname ) ) {
+        if ( std::remove( logname.c_str() ) != 0 ) {
             std::cerr << "Error removing the previous information log file.\n";
             return false;
         }
     }
 
-    if ( remove_files && fileExists( elogname ) ) {
-        if ( std::remove( elogname.c_str() ) != 0 ) {
-            std::cerr << "Error removing the previous error log file.\n";
-            return false;
-        }
-    }
-
     // initialize logger
-    logger = std::make_shared<AcmLogger>(ilogname, elogname);
+    logger = std::make_shared<AcmLogger>(logname);
     return true;
 }
 
@@ -481,7 +467,7 @@ int ACMBlobProducer::operator()(void) {
                 status = producer_ptr->produce(published_topic_ptr.get(), partition, RdKafka::Producer::RK_MSG_COPY, (void *)buf, bytes_read, NULL, NULL);
 
                 if (status != RdKafka::ERR_NO_ERROR) {
-                    logger->error("Production failure code " + RdKafka::err2str( status ) + " after reading " + bytes_read + " bytes.");
+                    logger->error("Production failure code " + RdKafka::err2str( status ) + " after reading " + std::to_string(bytes_read) + " bytes.");
                     break;
 
                 } else {
@@ -513,39 +499,39 @@ int ACMBlobProducer::operator()(void) {
 
 #ifndef _ASN1_CODEC_TESTS
 
-int main( int argc, char* argv[] )
+int main(int argc, char* argv[])
 {
     ACMBlobProducer acm_blob_producer{"ACMBlobProducer","ASN1 Processing Module"};
 
-    acm_blob_producer.addOption( 'c', "config", "Configuration file name and path.", true );
-    acm_blob_producer.addOption( 'C', "config-check", "Check the configuration file contents and output the settings.", false );
-    acm_blob_producer.addOption( 't', "produce-topic", "The name of the topic to produce.", true );
-    acm_blob_producer.addOption( 'p', "partition", "Consumer topic partition from which to read.", true );
-    acm_blob_producer.addOption( 'g', "group", "Consumer group identifier", true );
-    acm_blob_producer.addOption( 'b', "broker", "Broker address (localhost:9092)", true );
-    acm_blob_producer.addOption( 'd', "debug", "debug level.", true );
-    acm_blob_producer.addOption( 'v', "log-level", "The info log level [trace,debug,info,warning,error,critical,off]", true );
-    acm_blob_producer.addOption( 'D', "log-dir", "Directory for the log files.", true );
-    acm_blob_producer.addOption( 'R', "log-rm", "Remove specified/default log files if they exist.", false );
-    acm_blob_producer.addOption( 'i', "ilog", "Information log file name.", true );
-    acm_blob_producer.addOption( 'e', "elog", "Error log file name.", true );
-    acm_blob_producer.addOption( 'F', "file", "Input binary file", true );
-    acm_blob_producer.addOption( 'B', "blocksize", "The block size to read and write.", true );
-    acm_blob_producer.addOption( 'h', "help", "print out some help" );
+    acm_blob_producer.addOption('c', "config", "Configuration file name and path.", true);
+    acm_blob_producer.addOption('C', "config-check", "Check the configuration file contents and output the settings.", false);
+    acm_blob_producer.addOption('t', "produce-topic", "The name of the topic to produce.", true);
+    acm_blob_producer.addOption('p', "partition", "Consumer topic partition from which to read.", true);
+    acm_blob_producer.addOption('g', "group", "Consumer group identifier", true);
+    acm_blob_producer.addOption('b', "broker", "Broker address (localhost:9092)", true);
+    acm_blob_producer.addOption('d', "debug", "debug level.", true);
+    acm_blob_producer.addOption('v', "log-level", "The info log level [trace,debug,info,warning,error,critical,off]", true);
+    acm_blob_producer.addOption('D', "log-dir", "Directory for the log files.", true);
+    acm_blob_producer.addOption('R', "log-rm", "Remove specified/default log files if they exist.", false);
+    acm_blob_producer.addOption('i', "ilog", "Information log file name.", true);
+    acm_blob_producer.addOption('e', "elog", "Error log file name.", true);
+    acm_blob_producer.addOption('F', "file", "Input binary file", true);
+    acm_blob_producer.addOption('B', "blocksize", "The block size to read and write.", true);
+    acm_blob_producer.addOption('h', "help", "print out some help");
 
     if (!acm_blob_producer.parseArgs(argc, argv)) {
         acm_blob_producer.usage();
-        std::exit( EXIT_FAILURE );
+        std::exit(EXIT_FAILURE);
     }
 
     if (acm_blob_producer.optIsSet('h')) {
         acm_blob_producer.help();
-        std::exit( EXIT_SUCCESS );
+        std::exit(EXIT_SUCCESS);
     }
 
     // can set levels if needed here.
-    if ( !acm_blob_producer.make_loggers( acm_blob_producer.optIsSet('R') )) {
-        std::exit( EXIT_FAILURE );
+    if (!acm_blob_producer.make_loggers((acm_blob_producer.optIsSet('R')))) {
+        std::exit(EXIT_FAILURE);
     }
 
     // configuration check.
@@ -553,21 +539,21 @@ int main( int argc, char* argv[] )
         try {
             if (acm_blob_producer.configure()) {
                 acm_blob_producer.print_configuration();
-                std::exit( EXIT_SUCCESS );
+                std::exit(EXIT_SUCCESS);
             } else {
                 std::cerr << "Current configuration settings do not work.\n";
-                acm_blob_producer.logger->error( "current configuration settings do not work; exiting." );
-                std::exit( EXIT_FAILURE );
+                acm_blob_producer.logger->error("current configuration settings do not work; exiting.");
+                std::exit(EXIT_FAILURE);
             }
-        } catch ( std::exception& e ) {
+        } catch (std::exception& e) {
             std::cerr << "Fatal Exception: " << e.what() << '\n';
-            acm_blob_producer.logger->error( "exception: " + e.what() );
-            std::exit( EXIT_FAILURE );
+            acm_blob_producer.logger->error(e.what());
+            std::exit(EXIT_FAILURE);
         }
     }
 
     // The module will run and when it terminates return an appropriate error code.
-    std::exit( acm_blob_producer.run() );
+    std::exit(acm_blob_producer.run());
 }
 
 #endif


### PR DESCRIPTION
## Simplified Logging
The AcmLogger class has been simplified to only use one spdlog logger (instead of separate info & error spdlog loggers).

## Log Level Environment Variable
The log level for the ACM is now passed in the `run_acm.sh` script via the ACM_LOG_LEVEL environment variable, which has been added to the docker-compose files for the project.

## Additional Changes
- A `sample.env` file has been added to the project.
- The `docker-compose.yml` file now uses `Dockerfile` instead of `Dockerfile.standalone` since the latter doesn't execute the program.
- The run_acm.sh script is now copied over to the image in the `Dockerfile.standalone` file.

## Verification
- Unit tests have been verified to pass in the provided dev container.
- Passing the log level via the environment variable has been verified to work with docker-compose locally.
- Passing the log level via the environment variable has been verified to work in our dev cluster.