### PR TITLE
Log Level Review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ docs/html
 /asn1c_combined/J2735_201603DA.ASN
 
 .env
+settings.json
+asn1c_combined/compile.out
+asn1c_combined/converter-example
+asn1c_combined/converter-example.mk
+asn1c_combined/libasncodec.a

--- a/build_local.sh
+++ b/build_local.sh
@@ -57,6 +57,7 @@ compileSpecAndBuildLibrary(){
 buildACM(){
     # Build the ACM
     echo "${GREEN}Building ACM${NC}"
+    rm -r build
     mkdir build
     cd build
     cmake ..

--- a/build_local.sh
+++ b/build_local.sh
@@ -57,7 +57,10 @@ compileSpecAndBuildLibrary(){
 buildACM(){
     # Build the ACM
     echo "${GREEN}Building ACM${NC}"
-    rm -r build
+    if [ -d "./build" ]; then
+        echo "${INFO} Removing build directory"
+        rm -r build
+    fi
     mkdir build
     cd build
     cmake ..

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: ${DOCKER_HOST_IP}
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "j2735asn1xer:1:1,j2735asn1per:1:1"
+      KAFKA_CREATE_TOPICS: "j2735asn1xer:1:1,j2735asn1per:1:1,topic.Asn1DecoderInput:1:1, topic.Asn1DecoderOutput:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   asn1_codec:
@@ -29,6 +29,6 @@ services:
       DOCKER_HOST_IP: ${DOCKER_HOST_IP}
       KAFKA_TYPE: "ON-PREM"
       ACM_CONFIG_FILE: adm.properties
-      ACM_LOG_TO_CONSOLE: "true"
-      ACM_LOG_TO_FILE: "false"
-      ACM_LOG_LEVEL: ${ACM_LOG_LEVEL}
+      ACM_LOG_TO_CONSOLE: "${ACM_LOG_TO_CONSOLE}"
+      ACM_LOG_TO_FILE: "${ACM_LOG_TO_FILE}"
+      ACM_LOG_LEVEL: "${ACM_LOG_LEVEL}"

--- a/kafka-test/CMakeLists.txt
+++ b/kafka-test/CMakeLists.txt
@@ -32,6 +32,9 @@
 #      Cyber and Information Security Research (CISR) Group Oak Ridge National
 #      Laboratory
 #      865-804-5161 (mobile)
+
+# NOTE: THIS FILE IS DEPRECATED AS OF 5/17/2023 AND IS NOT RECOMMENDED FOR USE.
+
 cmake_minimum_required(VERSION 2.6)
 project(CVDIGeofenceTest)
 

--- a/kafka-test/CMakeLists.txt
+++ b/kafka-test/CMakeLists.txt
@@ -33,8 +33,6 @@
 #      Laboratory
 #      865-804-5161 (mobile)
 
-# NOTE: THIS FILE IS DEPRECATED AS OF 5/17/2023 AND IS NOT RECOMMENDED FOR USE.
-
 cmake_minimum_required(VERSION 2.6)
 project(CVDIGeofenceTest)
 

--- a/kafka-test/src/rdkafka_example.cpp
+++ b/kafka-test/src/rdkafka_example.cpp
@@ -32,8 +32,6 @@
  * (https://github.com/edenhill/librdkafka)
  */
 
-// NOTE: THIS FILE IS DEPRECATED AS OF 5/17/2023 AND IS NOT RECOMMENDED FOR USE.
-
 #include <iostream>
 #include <string>
 #include <cstdlib>

--- a/kafka-test/src/rdkafka_example.cpp
+++ b/kafka-test/src/rdkafka_example.cpp
@@ -32,6 +32,8 @@
  * (https://github.com/edenhill/librdkafka)
  */
 
+// NOTE: THIS FILE IS DEPRECATED AS OF 5/17/2023 AND IS NOT RECOMMENDED FOR USE.
+
 #include <iostream>
 #include <string>
 #include <cstdlib>

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -669,7 +669,7 @@ bool ASN1_Codec::make_loggers( bool remove_files ) {
                                                                                 // some other strange os...
 #endif
         {
-            std::cerr << "Error making the logging directory.\n"; // don't use logger since it is not yet initialized.
+            std::cerr << "Error making the logging directory." << std::endl; // don't use logger since it is not yet initialized.
             return false;
         }
     }
@@ -684,7 +684,7 @@ bool ASN1_Codec::make_loggers( bool remove_files ) {
 
     if ( remove_files && fileExists( logname ) ) {
         if ( std::remove( logname.c_str() ) != 0 ) {
-            std::cerr << "Error removing the previous information log file.\n"; // don't use logger since it is not yet initialized.
+            std::cerr << "Error removing the previous information log file." << std::endl; // don't use logger since it is not yet initialized.
             return false;
         }
     }

--- a/src/acm_blob_producer.cpp
+++ b/src/acm_blob_producer.cpp
@@ -141,28 +141,36 @@ ACMBlobProducer::~ACMBlobProducer()
 
 void ACMBlobProducer::print_configuration() const
 {
-    std::cout << "# Global config" << "\n";
+    logger->info("ACMBlobProducer global configuration settings:");
     std::list<std::string>* conf_list = conf->dump();
 
     int i = 0;
     for ( auto& v : *conf_list ) {
-        if ( i%2==0 ) std::cout << v << " = ";
-        else std::cout << v << '\n';
+        if ( i%2==0 ) {
+            logger->info( v + " = ");
+        }
+        else {
+            logger->info( v );
+        }
         ++i;
     }
 
-    std::cout << "# Topic config" << "\n";
+    logger->info("ACMBlobProducer topic configuration settings:");
     conf_list = tconf->dump();
     i = 0;
     for ( auto& v : *conf_list ) {
-        if ( i%2==0 ) std::cout << v << " = ";
-        else std::cout << v << '\n';
+        if ( i%2==0 ) {
+            logger->info( v + " = ");
+        }
+        else {
+            logger->info( v );
+        }
         ++i;
     }
 
-    std::cout << "# Module Specific config \n";
+    logger->info("ACMBlobProducer module specific configuration settings:");
     for ( const auto& m : mconf ) {
-        std::cout << m.first << " = " << m.second << '\n';
+        logger->info( m.first + " = " + m.second );
     }
 }
 
@@ -391,7 +399,7 @@ bool ACMBlobProducer::make_loggers( bool remove_files )
                                                                                 // some other strange os...
 #endif
         {
-            std::cerr << "Error making the logging directory.\n";
+            std::cerr << "Error making the logging directory." << std::endl; // do not use logger since it is not yet initialized.
             return false;
         }
     }
@@ -406,7 +414,7 @@ bool ACMBlobProducer::make_loggers( bool remove_files )
 
     if ( remove_files && fileExists( logname ) ) {
         if ( std::remove( logname.c_str() ) != 0 ) {
-            std::cerr << "Error removing the previous information log file.\n";
+            std::err << "Error removing the previous information log file." << std::endl; // do not use logger since it is not yet initialized.
             return false;
         }
     }
@@ -475,20 +483,18 @@ int ACMBlobProducer::operator()(void) {
                     logger->trace("Production success of " + std::to_string(bytes_read) + " bytes.");
                 }
 
-
-                std::cerr << "Bytes from file: " << bytes_read << ". Successfully produced to: " << published_topic_name << '\n';
+                logger->trace("Bytes from file: " + std::to_string(bytes_read) + ". Successfully produced to: " + published_topic_name);
             }
         }
 
         fclose( source );
         logger->info( "Finished producing the entire file.");
-        std::cerr << "Sleeping for 5 seconds after file round " << ++file_round << "\n";
+        logger->info("Sleeping for 5 seconds after file round " + std::to_string(++file_round) + "\n");
         std::this_thread::sleep_for( std::chrono::seconds(5) ); 
     }
 
     logger->info("ACMBlobProducer operations complete; shutting down...");
-    logger->info("ACMBlobProducer published : " + std::to_string(msg_send_count) + " blocks and " + std::to_string(msg_send_bytes) + " bytes");
-    std::cerr << "ACMBlobProducer published : " << msg_send_count << " binary blocks of size: " << block_size << " for " << msg_send_bytes << " bytes.\n";
+    logger->info("ACMBlobProducer published : " + std::to_string(msg_send_count) + " binary blocks of size: " + std::to_string(block_size) + " for " + std::to_string(msg_send_bytes) + " bytes.");
     
     // NOTE: good for troubleshooting, but bad for performance.
     logger->flush();
@@ -538,13 +544,11 @@ int main(int argc, char* argv[])
                 acm_blob_producer.print_configuration();
                 std::exit(EXIT_SUCCESS);
             } else {
-                std::cerr << "Current configuration settings do not work.\n";
                 acm_blob_producer.logger->error("current configuration settings do not work; exiting.");
                 std::exit(EXIT_FAILURE);
             }
         } catch (std::exception& e) {
-            std::cerr << "Fatal Exception: " << e.what() << '\n';
-            acm_blob_producer.logger->error(e.what());
+            acm_blob_producer.logger->error("Fatal Exception: " + std::string(e.what()));
             std::exit(EXIT_FAILURE);
         }
     }

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -280,7 +280,7 @@ bool Tool::parseArgs(int argc, char* argv[])
                 return false;
 
             case 1 :
-                std::cout << "not sure what this does... case 1. optarg = " << optarg << std::endl;
+                std::cerr << "Unknown case 1; optarg = " << optarg << std::endl;
                 break;
 
             case '?' :


### PR DESCRIPTION
## Changes
Reviewed and adjusted the log levels for each log statement as necessary.

Replaced std::cout & std::cerr with the logger whenever possible, except for certain cases:
- Error messages related to logger initialization.
- A log statement in `Tool.cpp`.
- A warning log statement if the logger is configured to not print to the console or a file.

## Additional Changes
- Added some files to `.gitignore`.
- Modified the `build_local.sh` script to remove the 'build' directory before compilation.
- Added the 'topic.Asn1DecoderInput' and 'topic.Asn1DecoderOutput' topics to the list of topics in `docker-compose.yml`.
- Marked the files in the `/kafka-test` directory as deprecated.

## Testing
- Verified the program compiles and starts using `build_local.sh` and `docker-compose.yml`.
- These changes have been deployed to our dev cluster and data has been verified to still be flowing.