### PR TITLE
Include J2735_2016 ASN file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ docs/html
 /.project
 /.settings/language.settings.xml
 /sh.exe.stackdump
-/asn1c_combined/J2735_201603DA.ASN
 
 .env
 settings.json

--- a/asn1c_combined/.gitignore
+++ b/asn1c_combined/.gitignore
@@ -1,6 +1,5 @@
 *.c
 *.h
-*.asn
 *.o
 Makefile*
 

--- a/asn1c_combined/J2735_201603DA.ASN
+++ b/asn1c_combined/J2735_201603DA.ASN
@@ -1,0 +1,5714 @@
+﻿-- Product Code: J2735ASN-201603 (also available 
+-- as a set with J2735-201603 Standard) 
+
+-- SAE J735-201603 Final ASN spec
+--
+--
+-- This product is provided by SAE to purchasers 
+-- as SAE J2735ASN-201603 (tm) as a companion product to 
+-- assist them in deployment of SAE Standard J2735-201603. 
+-- This document, like SAE J2735(tm) itself contains 
+-- material copyrighted by SAE International.
+--
+--
+-- This downloadable file contains an SAE standards ASN 
+-- file (the "ASN"). The ASN is a copyrighted work and all 
+-- rights, title, and interest in and to the ASN are owned
+-- by SAE. SAE hereby grants you a nonexclusive, 
+-- nontransferable license to have one single copy of the ASN, 
+-- for personal use or use by a single corporate entity on one
+-- computer only. This document is SAE International 
+-- Copyrighted Intellectual Property, prohibiting resale, 
+-- and/or distribution of any kind. 
+--
+-- SAE also hereby grants to you the nonexclusive, nontransferable
+-- right to use this ASN and create derivative works for your
+-- own or your own corporate entity’s research purposes, and in the 
+-- design, creation, manufacture, distribution, and use of your own
+-- products. For purposes of clarification, derivative works 
+-- permitted under this license include derivative works or source 
+-- code that do not include or incorporate this ASN. 
+-- The derivative work may use the ASN to create source code and 
+-- corresponding software programs. Notwithstanding the foregoing,
+-- you agree that you must obtain a license from SAE to create any 
+-- derivative works which incorporate this ASN or its contents.
+
+-- Further, SAE International is not responsible 
+-- for outcomes resulting from use of the ASN. Under no 
+-- circumstances shall SAE International be liable for any 
+-- costs, losses, expenses, or damages (whether direct or 
+-- indirect, consequential, special, economic, or financial,
+-- including any losses of profits) whatsoever that may be 
+-- incurred through the use of any information contained in 
+-- the ASN. (c) 2016 SAE International
+--
+--
+-- Output of SCSC registry data into file:
+-- C:\... /MiniEdit/Source.ASN
+-- in format need to operate on the ASN source files.
+-- 
+-- Run on Mini-Edit Version 3.2.454 from itsware.net
+-- From db release of J2735_r70.its
+-- Issued for final use March 7th 2016 by dck
+-- this edtion updates the Jan 8th 2916 release
+--
+-- NOTE:  The normative official source for this file
+-- can be downloaded from the SAE at this URL:
+-- http://www.sae.org/standardsdev/dsrc/
+--
+-- Please refer to SAE J2735 for normative details regarding
+-- how these data concepts are to be used. 
+-- The term J2735 is a trademark of the SAE.
+-- ###################################################
+-- 
+-- 
+-- Run this file with a line like:
+-- asn1 source.txt -errorfile errs.txt -noun
+-- 
+-- The local module consisting of DEs / DFs and MSGs
+
+
+
+-- The local module consisting of DEs / DFs and MSGs
+DSRC DEFINITIONS AUTOMATIC TAGS::= BEGIN 
+
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- Start of entries from table Messages...
+-- This table typically contains message entries.
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+
+MessageFrame ::= SEQUENCE {
+   messageId   MESSAGE-ID-AND-TYPE.&id({MessageTypes}),
+   value       MESSAGE-ID-AND-TYPE.&Type({MessageTypes}{@.messageId}),
+   ...
+   }
+
+MESSAGE-ID-AND-TYPE ::= CLASS {
+   &id    DSRCmsgID UNIQUE,
+   &Type
+   } WITH SYNTAX {&Type IDENTIFIED BY &id}
+
+MessageTypes MESSAGE-ID-AND-TYPE ::= {
+   { BasicSafetyMessage    IDENTIFIED BY basicSafetyMessage    } |       
+   { MapData               IDENTIFIED BY mapData               } |          
+   { SPAT                  IDENTIFIED BY signalPhaseAndTimingMessage } | 
+   { CommonSafetyRequest   IDENTIFIED BY commonSafetyRequest   } |  
+   { EmergencyVehicleAlert IDENTIFIED BY emergencyVehicleAlert } |  
+   { IntersectionCollision IDENTIFIED BY intersectionCollision } |  
+   { NMEAcorrections       IDENTIFIED BY nmeaCorrections       } |  
+   { ProbeDataManagement   IDENTIFIED BY probeDataManagement   } |
+   { ProbeVehicleData      IDENTIFIED BY probeVehicleData      } |  
+   { RoadSideAlert         IDENTIFIED BY roadSideAlert         } |      
+   { RTCMcorrections       IDENTIFIED BY rtcmCorrections       } |       
+   { SignalRequestMessage  IDENTIFIED BY signalRequestMessage  } |    
+   { SignalStatusMessage   IDENTIFIED BY signalStatusMessage   } |  
+   { TravelerInformation   IDENTIFIED BY travelerInformation   } |  
+   { PersonalSafetyMessage IDENTIFIED BY personalSafetyMessage } |  
+   { TestMessage00         IDENTIFIED BY testMessage00 } |
+   { TestMessage01         IDENTIFIED BY testMessage01 } | 
+   { TestMessage02         IDENTIFIED BY testMessage02 } |  
+   { TestMessage03         IDENTIFIED BY testMessage03 } | 
+   { TestMessage04         IDENTIFIED BY testMessage04 } |     
+   { TestMessage05         IDENTIFIED BY testMessage05 } | 
+   { TestMessage06         IDENTIFIED BY testMessage06 } |   
+   { TestMessage07         IDENTIFIED BY testMessage07 } |    
+   { TestMessage08         IDENTIFIED BY testMessage08 } |   
+   { TestMessage09         IDENTIFIED BY testMessage09 } |  
+   { TestMessage10         IDENTIFIED BY testMessage10 } |
+   { TestMessage11         IDENTIFIED BY testMessage11 } | 
+   { TestMessage12         IDENTIFIED BY testMessage12 } | 
+   { TestMessage13         IDENTIFIED BY testMessage13 } |
+   { TestMessage14         IDENTIFIED BY testMessage14 } |  
+   { TestMessage15         IDENTIFIED BY testMessage15 } ,
+   ... -- Expansion to be used only by the SAE J2735 DSRC TC
+   }
+
+
+-- Regional extensions support
+REG-EXT-ID-AND-TYPE ::= CLASS {
+   &id     RegionId UNIQUE,
+   &Type
+   } WITH SYNTAX {&Type IDENTIFIED BY &id}
+
+RegionalExtension {REG-EXT-ID-AND-TYPE : Set} ::= SEQUENCE {
+   regionId     REG-EXT-ID-AND-TYPE.&id( {Set} ),
+   regExtValue  REG-EXT-ID-AND-TYPE.&Type( {Set}{@regionId} )
+   }
+
+   
+   
+   
+BasicSafetyMessage ::= SEQUENCE {
+   -- Part I, Sent at all times with each message
+   coreData      BSMcoreData,   
+
+   -- Part II Content
+   partII        SEQUENCE (SIZE(1..8)) OF 
+                 PartIIcontent {{ BSMpartIIExtension }} OPTIONAL,
+   
+   regional      SEQUENCE (SIZE(1..4)) OF 
+                 RegionalExtension {{REGION.Reg-BasicSafetyMessage}} OPTIONAL,
+   ...
+   }
+
+-- BSM Part II content support
+PARTII-EXT-ID-AND-TYPE ::= CLASS {
+   &id     PartII-Id UNIQUE,
+   &Type
+   } WITH SYNTAX {&Type IDENTIFIED BY &id}
+
+PartIIcontent  { PARTII-EXT-ID-AND-TYPE: Set} ::= SEQUENCE {
+   partII-Id     PARTII-EXT-ID-AND-TYPE.&id( {Set} ),
+   partII-Value  PARTII-EXT-ID-AND-TYPE.&Type( {Set}{@partII-Id} )
+   }
+
+PartII-Id ::= INTEGER (0..63)
+   vehicleSafetyExt       PartII-Id::= 0  -- VehicleSafetyExtensions
+   specialVehicleExt      PartII-Id::= 1  -- SpecialVehicleExtensions
+   supplementalVehicleExt PartII-Id::= 2  -- SupplementalVehicleExtensions
+   -- NOTE: new registered Part II content IDs will be denoted here
+
+-- In a given message there may be multiple extensions present 
+-- but at most one instance of each extension type.
+BSMpartIIExtension  PARTII-EXT-ID-AND-TYPE ::= { 
+   { VehicleSafetyExtensions       IDENTIFIED BY vehicleSafetyExt} |
+   { SpecialVehicleExtensions      IDENTIFIED BY specialVehicleExt} |
+   { SupplementalVehicleExtensions IDENTIFIED BY supplementalVehicleExt} ,
+   ... 
+   }   
+
+   
+   
+   
+CommonSafetyRequest ::= SEQUENCE {
+   timeStamp   MinuteOfTheYear             OPTIONAL,
+   msgCnt      MsgCount                    OPTIONAL, 
+   id          TemporaryID                 OPTIONAL, -- targeted remote device              
+   requests    RequestedItemList,
+   -- Note: Above no longer uses the same request as probe management
+   regional    SEQUENCE (SIZE(1..4)) OF 
+               RegionalExtension {{REGION.Reg-CommonSafetyRequest}} OPTIONAL,
+   ...
+   }
+
+
+
+
+EmergencyVehicleAlert ::= SEQUENCE {
+   timeStamp       MinuteOfTheYear OPTIONAL,
+   id              TemporaryID OPTIONAL, 
+   rsaMsg          RoadSideAlert, 
+		   -- the DSRCmsgID inside this 
+                   -- data frame is set as per the 
+                   -- RoadSideAlert.  
+   responseType    ResponseType                   OPTIONAL, 
+   details         EmergencyDetails               OPTIONAL,   
+                   -- Combines these 3 items: 
+                   -- SirenInUse,                     
+                   -- LightbarInUse,                  
+                   -- MultiVehicleReponse,
+
+   mass            VehicleMass                    OPTIONAL,
+   basicType       VehicleType                    OPTIONAL,  
+                                -- gross size and axle cnt
+   
+   -- type of vehicle and agency when known
+   vehicleType     ITIS.VehicleGroupAffected      OPTIONAL,      
+   responseEquip   ITIS.IncidentResponseEquipment OPTIONAL, 
+   responderType   ITIS.ResponderGroupAffected    OPTIONAL,    
+   regional        SEQUENCE (SIZE(1..4)) OF 
+                   RegionalExtension {{REGION.Reg-EmergencyVehicleAlert}} OPTIONAL,
+   ...
+   }
+
+
+
+
+IntersectionCollision ::= SEQUENCE {
+   msgCnt         MsgCount,                 
+   id             TemporaryID,               
+   timeStamp      MinuteOfTheYear OPTIONAL,
+   partOne        BSMcoreData OPTIONAL, 
+   path           PathHistory OPTIONAL, 
+                  -- a set of recent path points forming a history
+   pathPrediction PathPrediction OPTIONAL,
+                  -- the predicted path
+   intersectionID IntersectionReferenceID, 
+                  -- the applicable Intersection
+   laneNumber     ApproachOrLane,
+                  -- the best estimate of the applicable Lane or Approach
+   eventFlag      VehicleEventFlags,
+                  -- used to convey vehicle Panic Events,  
+                  -- Set to indicate "Intersection Violation" 
+   regional       SEQUENCE (SIZE(1..4)) OF 
+                  RegionalExtension {{REGION.Reg-IntersectionCollision}} OPTIONAL,
+   ...
+   }
+
+
+
+
+MapData ::= SEQUENCE {
+   timeStamp         MinuteOfTheYear OPTIONAL, 
+   msgIssueRevision  MsgCount,        
+   layerType         LayerType OPTIONAL,
+   layerID           LayerID  OPTIONAL,
+   intersections     IntersectionGeometryList OPTIONAL,
+                     -- All Intersection definitions 
+   roadSegments      RoadSegmentList OPTIONAL,
+                     -- All roadway descriptions
+  
+   dataParameters    DataParameters OPTIONAL,
+                     -- Any meta data regarding the map contents
+   
+   restrictionList   RestrictionClassList OPTIONAL,
+                     -- Any restriction ID tables which have  
+                     -- established for these map entries 
+   regional          SEQUENCE (SIZE(1..4)) OF 
+                     RegionalExtension {{REGION.Reg-MapData}} OPTIONAL,
+   
+   -- NOTE:
+   -- Other map data will be added here as it is defined
+   -- Examples of the type of content to be added include
+   -- curve warnings, construction routes, etc.
+   ...
+   }
+
+
+
+
+NMEAcorrections ::= SEQUENCE {
+   timeStamp MinuteOfTheYear    OPTIONAL,
+   rev       NMEA-Revision      OPTIONAL,
+             -- the specific edition of the standard
+             -- that is being sent, 4.x at the time of publication
+   msg       NMEA-MsgType       OPTIONAL,
+             -- the message and sub-message type, as
+             -- defined in the revision being used
+   -- NOTE The message type is also in the payload expressed as a string, 
+   wdCount   ObjectCount        OPTIONAL,
+             -- a count of octets to follow
+             -- observe that not all NMEA sentences are limited to 82 characters 
+   payload   NMEA-Payload, 
+   regional  SEQUENCE (SIZE(1..4)) OF 
+             RegionalExtension {{REGION.Reg-NMEAcorrections}} OPTIONAL,
+   ...
+   }
+
+
+
+
+PersonalSafetyMessage ::= SEQUENCE {
+   basicType           PersonalDeviceUserType,  
+   secMark             DSecond,  
+   msgCnt              MsgCount,  
+   id                  TemporaryID,
+   position            Position3D, --  Lat, Long, Elevation     
+   accuracy            PositionalAccuracy,  
+   speed               Velocity,
+   heading             Heading,               
+   accelSet            AccelerationSet4Way        OPTIONAL,  
+   pathHistory         PathHistory                OPTIONAL, 
+   pathPrediction      PathPrediction             OPTIONAL,
+   propulsion          PropelledInformation       OPTIONAL,
+   useState            PersonalDeviceUsageState   OPTIONAL,
+   crossRequest        PersonalCrossingRequest    OPTIONAL,
+   crossState          PersonalCrossingInProgress OPTIONAL,
+   clusterSize         NumberOfParticipantsInCluster        OPTIONAL,
+   clusterRadius       PersonalClusterRadius      OPTIONAL,
+   eventResponderType  PublicSafetyEventResponderWorkerType OPTIONAL,
+   activityType        PublicSafetyAndRoadWorkerActivity    OPTIONAL,
+   activitySubType     PublicSafetyDirectingTrafficSubType  OPTIONAL,
+   assistType          PersonalAssistive          OPTIONAL,
+   sizing              UserSizeAndBehaviour       OPTIONAL, 
+   attachment          Attachment                 OPTIONAL,
+   attachmentRadius    AttachmentRadius           OPTIONAL,
+   animalType          AnimalType                 OPTIONAL,
+
+   regional SEQUENCE (SIZE(1..4)) OF 
+            RegionalExtension {{REGION.Reg-PersonalSafetyMessage}} OPTIONAL,
+   ...
+   }
+
+
+
+
+ProbeDataManagement ::= SEQUENCE {
+   timeStamp            MinuteOfTheYear OPTIONAL, 
+   sample               Sample,           -- Identifies the vehicle  
+                                          -- population affected by this
+   directions           HeadingSlice,     -- Applicable headings/directions
+   term CHOICE {                          
+      termtime          TermTime,         -- Terminate this management process 
+                                          -- based on Time-to-Live
+      termDistance      TermDistance      -- Terminate management process 
+                                          -- based on Distance-to-Live
+      },
+   snapshot CHOICE {
+      snapshotTime      SnapshotTime,     -- Collect snapshots based on Time
+                                          -- the value 0 indicates forever
+      snapshotDistance  SnapshotDistance  -- Collect snapshots based on combination 
+                                          -- of vehicle Speed and Distance
+      },
+   txInterval           SecondOfTime,     -- Time Interval at which to send snapshots
+   dataElements         VehicleStatusRequestList OPTIONAL,
+                                          -- Control data frames and associated 
+                                          -- trigger thresholds to be changed 
+   regional             SEQUENCE (SIZE(1..4)) OF 
+                        RegionalExtension {{REGION.Reg-ProbeDataManagement}} OPTIONAL,
+   ...
+   }
+
+
+
+
+ProbeVehicleData ::= SEQUENCE {
+   timeStamp       MinuteOfTheYear OPTIONAL,
+   segNum          ProbeSegmentNumber OPTIONAL,   
+                                         -- a short term Ident value
+                                         -- not used when ident is used
+   probeID         VehicleIdent OPTIONAL, 
+                                         -- identity data for selected 
+                                         -- types of vehicles    
+   startVector     FullPositionVector,   -- the space and time of 
+                                         -- transmission to the RSU
+   vehicleType     VehicleClassification, -- type of vehicle, 
+   snapshots       SEQUENCE (SIZE(1..32)) OF Snapshot,               
+                                         -- a seq of name-value pairs 
+                                         -- along with the space and time 
+                                         -- of the first measurement set
+   regional        SEQUENCE (SIZE(1..4)) OF 
+                   RegionalExtension {{REGION.Reg-ProbeVehicleData}} OPTIONAL,
+   ...
+   }
+
+
+
+
+RoadSideAlert ::= SEQUENCE { 
+   msgCnt        MsgCount,   
+   timeStamp     MinuteOfTheYear  OPTIONAL,
+   typeEvent     ITIS.ITIScodes,
+                 -- a category and an item from that category 
+                 -- all ITS stds use the same types here
+                 -- to explain the type of  the 
+                 -- alert / danger / hazard involved
+   description   SEQUENCE (SIZE(1..8)) OF ITIS.ITIScodes OPTIONAL,
+                 -- up to eight ITIS code set entries to further
+                 -- describe the event, give advice, or any 
+                 -- other ITIS codes
+   priority      Priority OPTIONAL,  
+                 -- the urgency of this message, a relative
+                 -- degree of merit compared with other 
+                 -- similar messages for this type (not other
+                 -- messages being sent by the device), nor a 
+                 -- priority of display urgency
+   heading       HeadingSlice  OPTIONAL,       
+                 -- Applicable headings/direction
+   extent        Extent OPTIONAL,  
+                 -- the spatial distance over which this
+                 -- message applies and should be presented 
+                 -- to the driver
+   position      FullPositionVector OPTIONAL, 
+                 -- a compact summary of the position,
+                 -- heading, speed, etc. of the 
+                 -- event in question. Including stationary
+                 -- and wide area events. 
+   furtherInfoID FurtherInfoID OPTIONAL,
+                 -- an index link to any other incident 
+                 -- information data that may be available 
+                 -- in the normal ATIS incident description 
+                 -- or other messages
+                 -- 1~2 octets in length
+   regional      SEQUENCE (SIZE(1..4)) OF 
+                 RegionalExtension {{REGION.Reg-RoadSideAlert}} OPTIONAL,
+   ...
+   }
+
+
+
+
+RTCMcorrections ::= SEQUENCE {
+   msgCnt      MsgCount, 
+   rev         RTCM-Revision,
+               -- the specific edition of the standard
+               -- that is being sent
+   timeStamp   MinuteOfTheYear  OPTIONAL,
+
+   -- Observer position, if needed
+   anchorPoint FullPositionVector OPTIONAL,
+   -- Precise ant position and noise data for a rover
+   rtcmHeader  RTCMheader OPTIONAL,  
+                    
+   -- one or more RTCM messages
+   msgs        RTCMmessageList,
+   regional    SEQUENCE (SIZE(1..4)) OF 
+               RegionalExtension {{REGION.Reg-RTCMcorrections}} OPTIONAL,
+   ...
+   }
+
+
+
+
+SPAT ::= SEQUENCE { 
+   timeStamp     MinuteOfTheYear OPTIONAL,  
+   name          DescriptiveName OPTIONAL, 
+                 -- human readable name for this collection 
+                 -- to be used only in debug mode
+   
+   intersections IntersectionStateList,
+                 -- sets of SPAT data (one per intersection)  
+   
+   -- If PrioritizationResponse data is required, it is found 
+   -- in the RegionalSPAT entry below
+   
+   regional      SEQUENCE (SIZE(1..4)) OF 
+                 RegionalExtension {{REGION.Reg-SPAT}} OPTIONAL,
+   ...
+   }
+
+
+
+
+SignalRequestMessage ::= SEQUENCE {    
+   timeStamp       MinuteOfTheYear  OPTIONAL,
+   second          DSecond,
+   sequenceNumber  MsgCount         OPTIONAL,
+
+   requests        SignalRequestList OPTIONAL,
+                   -- Request Data for one or more signalized 
+                   -- intersections that support SRM dialogs
+
+   requestor       RequestorDescription,
+                   -- Requesting Device and other User Data
+                   -- contains vehicle ID (if from a vehicle)
+                   -- as well as type data and current position
+                   -- and may contain additional transit data
+
+   regional        SEQUENCE (SIZE(1..4)) OF 
+                   RegionalExtension {{REGION.Reg-SignalRequestMessage}} OPTIONAL,
+   ...
+   }
+
+
+
+
+SignalStatusMessage ::= SEQUENCE {
+   timeStamp       MinuteOfTheYear  OPTIONAL,
+   second          DSecond,
+   sequenceNumber  MsgCount         OPTIONAL,            
+
+   -- Status Data for one of more signalized intersections
+   status          SignalStatusList,
+ 
+   regional        SEQUENCE (SIZE(1..4)) OF 
+                   RegionalExtension {{REGION.Reg-SignalStatusMessage}} OPTIONAL,
+   ...
+   }
+
+
+
+
+TravelerInformation ::= SEQUENCE {
+   msgCnt      MsgCount,  
+   timeStamp   MinuteOfTheYear OPTIONAL,
+   packetID    UniqueMSGID     OPTIONAL,    
+   urlB        URL-Base        OPTIONAL,  
+
+   -- A set of one or more self contained 
+   -- traveler information messages (frames)
+   dataFrames  TravelerDataFrameList,
+ 
+   regional    SEQUENCE (SIZE(1..4)) OF 
+               RegionalExtension {{REGION.Reg-TravelerInformation}} OPTIONAL,
+   ...
+   }
+
+
+
+
+TestMessage00 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   -- All content is added in below data frame
+   regional  RegionalExtension {{REGION.Reg-TestMessage00}} OPTIONAL,
+   ...
+   }
+TestMessage01 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage01}} OPTIONAL,
+   ...
+   }
+TestMessage02 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage02}} OPTIONAL,
+   ...  
+   }
+TestMessage03 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage03}} OPTIONAL,
+   ...  
+   }
+TestMessage04 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage04}} OPTIONAL,
+   ...  
+   }
+TestMessage05 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage05}} OPTIONAL,
+   ...  
+   }
+TestMessage06 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage06}} OPTIONAL,
+   ...  
+   }
+TestMessage07 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage07}} OPTIONAL,
+   ...  
+   }
+TestMessage08 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage08}} OPTIONAL,
+   ...  
+   }
+TestMessage09 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage09}} OPTIONAL,
+   ...  
+   }
+TestMessage10 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage10}} OPTIONAL,
+   ...  
+   }
+TestMessage11 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage11}} OPTIONAL,
+   ...  
+   }
+TestMessage12 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage12}} OPTIONAL,
+   ...  
+   }
+TestMessage13 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage13}} OPTIONAL,
+   ...  
+   }
+TestMessage14 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage14}} OPTIONAL,
+   ...  
+   }
+TestMessage15 ::= SEQUENCE {
+   header    Header   OPTIONAL,
+   regional  RegionalExtension {{REGION.Reg-TestMessage15}} OPTIONAL,
+   ...  
+   }
+
+   
+   
+
+
+
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- Start of entries from table Data_Frames...
+-- This table typically contains data frame entries.
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+ 
+
+AccelerationSet4Way ::= SEQUENCE {
+   long Acceleration,          -- Along the Vehicle Longitudinal axis
+   lat  Acceleration,          -- Along the Vehicle Lateral axis
+   vert VerticalAcceleration,  -- Along the Vehicle Vertical axis
+   yaw  YawRate
+}
+
+
+AccelSteerYawRateConfidence ::= SEQUENCE {
+   yawRate             YawRateConfidence, 
+   acceleration        AccelerationConfidence, 
+   steeringWheelAngle  SteeringWheelAngleConfidence 
+   }
+
+   
+AdvisorySpeed ::= SEQUENCE {
+   type        AdvisorySpeedType,
+               -- the type of advisory which this is.
+   speed       SpeedAdvice OPTIONAL,
+               -- See Section 11 for converting and translating speed 
+               -- expressed in mph into units of m/s
+               -- This element is optional ONLY when superceded 
+               -- by the presence of a regional speed element found in
+               -- Reg-AdvisorySpeed entry
+   confidence  SpeedConfidence OPTIONAL,
+               -- A confidence value for the above speed
+   distance    ZoneLength OPTIONAL,
+               -- Unit = 1 meter,  
+               -- The distance indicates the region for which the advised speed 
+               -- is recommended, it is specified upstream from the stop bar  
+               -- along the connected egressing lane
+   class       RestrictionClassID OPTIONAL,
+               -- the vehicle types to which it applies
+               -- when absent, the AdvisorySpeed applies to
+               -- all motor vehicle types
+   regional    SEQUENCE (SIZE(1..4)) OF 
+               RegionalExtension {{REGION.Reg-AdvisorySpeed}} OPTIONAL,
+   ...
+   }
+
+
+AdvisorySpeedList ::= SEQUENCE (SIZE(1..16)) OF AdvisorySpeed
+
+
+AntennaOffsetSet ::= SEQUENCE { 
+   antOffsetX  Offset-B12, -- a range of +- 20.47 meters
+   antOffsetY  Offset-B09, -- a range of +- 2.55 meters
+   antOffsetZ  Offset-B10  -- a range of +- 5.11 meters
+   }
+
+
+ApproachOrLane ::= CHOICE {
+   approach   ApproachID,
+   lane       LaneID
+   }
+
+
+BrakeSystemStatus ::= SEQUENCE { 
+   wheelBrakes        BrakeAppliedStatus,
+   traction           TractionControlStatus,
+   abs                AntiLockBrakeStatus, 
+   scs                StabilityControlStatus,
+   brakeBoost         BrakeBoostApplied, 
+   auxBrakes          AuxiliaryBrakeStatus
+   }
+
+
+BSMcoreData ::= SEQUENCE {   
+   msgCnt        MsgCount,  
+   id            TemporaryID,
+   secMark       DSecond,
+   lat           Latitude,              
+   long          Longitude,             
+   elev          Elevation,             
+   accuracy      PositionalAccuracy,    
+   transmission  TransmissionState,
+   speed         Speed,
+   heading       Heading,               
+   angle         SteeringWheelAngle,    
+   accelSet      AccelerationSet4Way,   
+   brakes        BrakeSystemStatus,     
+   size          VehicleSize          
+   }
+
+
+BumperHeights ::= SEQUENCE {
+   front      BumperHeight, 
+   rear       BumperHeight
+   }
+
+
+Circle ::= SEQUENCE {
+   center   Position3D,
+   radius   Radius-B12, 
+   units    DistanceUnits
+   }
+
+
+ComputedLane ::= SEQUENCE {
+   -- Data needed to created a computed lane
+   referenceLaneId    LaneID,
+                         -- the lane ID upon which this 
+                         -- computed lane will be based 
+   -- Lane Offset in X and Y direction
+   offsetXaxis        CHOICE {
+                         small   DrivenLineOffsetSm, 
+                         large   DrivenLineOffsetLg
+                         },  
+   offsetYaxis        CHOICE {
+                         small   DrivenLineOffsetSm, 
+                         large   DrivenLineOffsetLg
+                         },  
+                         -- A path X offset value for translations of the 
+                         -- path's points when creating translated lanes. 
+                         -- The values found in the reference lane are 
+                         -- all offset based on the X and Y values from 
+                         -- the coordinates of the reference lane's 
+                         -- initial path point.   
+   -- Lane Rotation
+   rotateXY           Angle OPTIONAL, 
+                         -- A path rotation value for the entire lane
+                         -- Observe that this rotates the existing orientation 
+                         -- of the referenced lane, it does not replace it.
+                         -- Rotation occurs about the initial path point.
+   -- Lane Path Scale (zooming)
+   scaleXaxis         Scale-B12 OPTIONAL, 
+   scaleYaxis         Scale-B12 OPTIONAL, 
+                         -- value for translations or zooming of the path's 
+                         -- points. The values found in the reference lane 
+                         -- are all expanded or contracted based on the X 
+                         -- and Y and width values from the coordinates of 
+                         -- the reference lane's initial path point.  
+                         -- The Z axis remains untouched.  
+   regional  SEQUENCE (SIZE(1..4)) OF 
+             RegionalExtension {{REGION.Reg-ComputedLane}} OPTIONAL,
+   ... 
+   }
+
+
+ConfidenceSet ::= SEQUENCE {
+   accelConfidence      AccelSteerYawRateConfidence OPTIONAL,    
+   speedConfidence      SpeedandHeadingandThrottleConfidence OPTIONAL,      
+   timeConfidence       TimeConfidence OPTIONAL,           
+   posConfidence        PositionConfidenceSet OPTIONAL,           
+   steerConfidence      SteeringWheelAngleConfidence OPTIONAL,
+   headingConfidence    HeadingConfidence OPTIONAL,
+   throttleConfidence   ThrottleConfidence OPTIONAL,
+   ...  
+   }
+
+
+ConnectingLane ::= SEQUENCE {
+   lane      LaneID,   -- Index of the connecting lane
+   maneuver  AllowedManeuvers OPTIONAL
+                       -- The Maneuver between 
+                       -- the enclosing lane and this lane
+                       -- at the stop line to connect them
+   }
+
+
+Connection ::= SEQUENCE {
+   -- The subject lane connecting to this lane is:
+   connectingLane     ConnectingLane, 
+                      -- The index of the connecting lane and also
+                      -- the maneuver from the current lane to it
+   remoteIntersection IntersectionReferenceID OPTIONAL,  
+                      -- This entry is only used when the 
+                      -- indicated connecting lane belongs 
+                      -- to another intersection layout. This 
+                      -- provides a means to create meshes of lanes
+   
+   -- SPAT mapping details at the stop line are:
+   signalGroup        SignalGroupID OPTIONAL,    
+                      -- The matching signal group send by 
+                      -- the SPAT message for this lane/maneuver.
+                      -- Shall be present unless the connectingLane 
+                      -- has no signal group (is un-signalized)
+   userClass          RestrictionClassID OPTIONAL, 
+                      -- The Restriction Class of users this applies to
+                      -- The use of some lane/maneuver and SignalGroupID 
+                      -- pairings are restricted to selected users.
+                      -- When absent, the SignalGroupID applies to all
+   
+   -- Movement assist details are given by:
+   connectionID       LaneConnectionID OPTIONAL
+                      -- An optional connection index used to 
+                      -- relate this lane connection to any dynamic 
+                      -- clearance data in the SPAT. Note that
+                      -- the index may be shared with other 
+                      -- connections if the clearance data is common
+   }
+
+
+ConnectionManeuverAssist ::= SEQUENCE {
+   connectionID         LaneConnectionID,
+                        -- the common connectionID used by all lanes to which
+                        -- this data applies 
+                        -- (this value traces to ConnectsTo entries in lanes)
+   -- Expected Clearance Information
+   queueLength          ZoneLength OPTIONAL,
+                        -- Unit = 1 meter, 0 = no queue
+                        -- The distance from the stop line to the back 
+                        -- edge of the last vehicle in the queue,                     
+                        -- as measured along the lane center line.
+   availableStorageLength ZoneLength OPTIONAL,
+                        -- Unit = 1 meter, 0 = no space remains
+                        -- Distance (e.g. beginning from the downstream 
+                        -- stop-line up to a given distance) with a high 
+                        -- probability for successfully executing the 
+                        -- connecting maneuver between the two lanes 
+                        -- during the current cycle. 
+                        -- Used for enhancing the awareness of vehicles 
+                        -- to anticipate if they can pass the stop line
+                        -- of the lane. Used for optimizing the green wave, 
+                        -- due to knowledge of vehicles waiting in front 
+                        -- of a red light (downstream).
+                        -- The element nextTime in TimeChangeDetails
+                        -- in the containing data frame contains the next 
+                        -- timemark at which an active phase is expected, 
+                        -- a form of storage flush interval.
+   waitOnStop           WaitOnStopline OPTIONAL,
+                        -- If "true", the vehicles on this specific connecting 
+                        -- maneuver have to stop on the stop-line and not 
+                        -- to enter the collision area 
+   pedBicycleDetect     PedestrianBicycleDetect OPTIONAL,
+                        -- true if ANY ped or bicycles are detected crossing 
+                        -- the above lanes. Set to false ONLY if there is a 
+                        -- high certainty that there are none present, 
+                        -- otherwise element is not sent.
+   regional  SEQUENCE (SIZE(1..4)) OF 
+             RegionalExtension {{REGION.Reg-ConnectionManeuverAssist}} OPTIONAL,
+   ...  
+   }
+
+
+ConnectsToList ::= SEQUENCE (SIZE(1..16)) OF Connection
+
+
+DataParameters ::= SEQUENCE {
+   processMethod     IA5String(SIZE(1..255)) OPTIONAL, 
+   processAgency     IA5String(SIZE(1..255)) OPTIONAL, 
+   lastCheckedDate   IA5String(SIZE(1..255)) OPTIONAL, 
+   geoidUsed         IA5String(SIZE(1..255)) OPTIONAL, 
+   ...  
+   }
+
+
+DDate ::= SEQUENCE {
+   year    DYear,       
+   month   DMonth,   
+   day     DDay    
+   }
+
+
+DDateTime ::= SEQUENCE {
+   year    DYear    OPTIONAL,    
+   month   DMonth   OPTIONAL,   
+   day     DDay     OPTIONAL,  
+   hour    DHour    OPTIONAL,   
+   minute  DMinute  OPTIONAL,  
+   second  DSecond  OPTIONAL,  
+   offset  DOffset  OPTIONAL -- time zone
+   }
+
+
+DFullTime ::= SEQUENCE {
+   year    DYear,      
+   month   DMonth,      
+   day     DDay,    
+   hour    DHour,  
+   minute  DMinute   
+   }
+
+
+DMonthDay ::= SEQUENCE {
+   month   DMonth,   
+   day     DDay       
+   }
+
+
+DTime ::= SEQUENCE {
+   hour    DHour,        
+   minute  DMinute,         
+   second  DSecond,          
+   offset  DOffset  OPTIONAL -- time zone
+   }
+
+
+DYearMonth ::= SEQUENCE {
+   year    DYear,       
+   month   DMonth         
+   }
+
+
+DisabledVehicle ::= SEQUENCE {
+   statusDetails     ITIS.ITIScodes(523..541),   
+                     -- Codes 532 to 541, as taken from J2540:
+                     -- Disabled, etc.
+                       -- stalled-vehicle (532),
+                       -- abandoned-vehicle (533),
+                       -- disabled-vehicle (534),
+                       -- disabled-truck (535),
+                       -- disabled-semi-trailer (536), -^- Alt: disabled
+                     -- tractor-trailer
+                       -- disabled-bus (537),
+                       -- disabled-train (538),
+                       -- vehicle-spun-out (539),
+                       -- vehicle-on-fire (540),
+                       -- vehicle-in-water (541),
+   locationDetails   ITIS.GenericLocations   OPTIONAL, 
+   ...       
+   }
+
+
+EmergencyDetails ::= SEQUENCE {
+   -- CERT SSP Privilege Details
+   sspRights    SSPindex, -- index set by CERT
+   sirenUse     SirenInUse,                 
+   lightsUse    LightbarInUse,              
+   multi        MultiVehicleResponse,
+   events       PrivilegedEvents OPTIONAL,
+   responseType ResponseType OPTIONAL,
+   ...
+   }
+
+
+EnabledLaneList ::= SEQUENCE (SIZE(1..16)) OF LaneID
+   -- The unique ID numbers for each
+   -- lane object which is 'active' 
+   -- as part of the dynamic map contents.
+
+
+EventDescription ::= SEQUENCE {
+   typeEvent     ITIS.ITIScodes,
+                 -- A category and an item from that category 
+                 -- all ITS stds use the same types here
+                 -- to explain the type of  the 
+                 -- alert / danger / hazard involved
+   description   SEQUENCE (SIZE(1..8)) OF ITIS.ITIScodes OPTIONAL,
+                 -- Up to eight ITIS code set entries to further
+                 -- describe the event, give advice, or any 
+                 -- other ITIS codes
+   priority      Priority OPTIONAL,  
+                 -- The urgency of this message, a relative
+                 -- degree of merit compared with other 
+                 -- similar messages for this type (not other
+                 -- messages being sent by the device), nor  
+                 -- is it a priority of display urgency
+   heading       HeadingSlice  OPTIONAL,       
+                 -- Applicable headings/direction
+   extent        Extent OPTIONAL,  
+                 -- The spatial distance over which this
+                 -- message applies and should be presented to the driver
+   regional      SEQUENCE (SIZE(1..4)) OF 
+                 RegionalExtension {{REGION.Reg-EventDescription}} OPTIONAL,
+   ...
+   }
+
+
+FullPositionVector ::= SEQUENCE {
+   utcTime             DDateTime OPTIONAL,   -- time with mSec precision
+   long                Longitude,            -- 1/10th microdegree
+   lat                 Latitude,             -- 1/10th microdegree
+   elevation           Elevation  OPTIONAL,  -- units of 0.1 m
+   heading             Heading OPTIONAL, 
+   speed               TransmissionAndSpeed OPTIONAL,
+   posAccuracy         PositionalAccuracy OPTIONAL,
+   timeConfidence      TimeConfidence OPTIONAL,
+   posConfidence       PositionConfidenceSet OPTIONAL,
+   speedConfidence     SpeedandHeadingandThrottleConfidence OPTIONAL, 
+   ...  
+   }
+
+
+GenericLane ::= SEQUENCE { 
+   laneID           LaneID, 
+                    -- The unique ID number assigned 
+                    -- to this lane object
+   name             DescriptiveName OPTIONAL,        
+                    -- often for debug use only 
+                    -- but at times used to name ped crossings
+   ingressApproach  ApproachID OPTIONAL, -- inbound
+   egressApproach   ApproachID OPTIONAL, -- outbound
+                    -- Approach IDs to which this lane belongs
+   laneAttributes   LaneAttributes, 
+                    -- All Attribute information about 
+                    -- the basic selected lane type
+                    -- Directions of use, Geometric co-sharing
+                    -- and Type Specific Attributes
+                    -- These Attributes are 'lane - global' that is,
+                    -- they are true for the entire length of the lane
+   maneuvers        AllowedManeuvers OPTIONAL,
+                    -- the permitted maneuvers for this lane
+   nodeList         NodeListXY,
+                    -- Lane spatial path information as well as
+                    -- various Attribute information along the node path  
+                    -- Attributes found here are more general and may
+                    -- come and go over the length of the lane.
+   connectsTo       ConnectsToList OPTIONAL, 
+                    -- a list of other lanes and their signal group IDs
+                    -- each connecting lane and its signal group ID
+                    -- is given, therefore this element provides the
+                    -- information formerly in "signalGroups" in prior
+                    -- editions.
+   overlays         OverlayLaneList OPTIONAL, 
+                    -- A list of any lanes which have spatial paths that
+                    -- overlay (run on top of, and not simply cross) 
+                    -- the path of this lane when used
+   regional  SEQUENCE (SIZE(1..4)) OF 
+             RegionalExtension {{REGION.Reg-GenericLane}} OPTIONAL,
+   ...
+   }
+
+
+GeographicalPath ::= SEQUENCE {
+   name             DescriptiveName          OPTIONAL,
+   id               RoadSegmentReferenceID   OPTIONAL,
+   anchor           Position3D               OPTIONAL, 
+   laneWidth        LaneWidth                OPTIONAL, 
+   directionality   DirectionOfUse           OPTIONAL, 
+   closedPath       BOOLEAN                  OPTIONAL, 
+                    -- when true, last point closes to first
+   direction        HeadingSlice             OPTIONAL, 
+                    -- field of view over which this applies
+   description CHOICE  {
+      path         OffsetSystem,
+                   -- The XYZ and LLH system of paths
+      geometry     GeometricProjection,
+                   -- A projected circle from a point
+      oldRegion    ValidRegion,  
+                   -- Legacy method, no longer recommended for use
+      ...
+      } OPTIONAL,
+   
+   regional   SEQUENCE (SIZE(1..4)) OF 
+            RegionalExtension {{REGION.Reg-GeographicalPath}} OPTIONAL,
+   ...  
+   }
+
+
+GeometricProjection ::= SEQUENCE {
+   direction        HeadingSlice,
+                    -- field of view over which this applies,
+   extent           Extent OPTIONAL,  
+                    -- the spatial distance over which this
+                    -- message applies and should be presented
+   laneWidth        LaneWidth OPTIONAL, -- used when a width is needed
+   circle           Circle, -- A point and radius
+
+   regional         SEQUENCE (SIZE(1..4)) OF 
+                    RegionalExtension {{REGION.Reg-GeometricProjection}} OPTIONAL,
+   ...  
+   }
+
+
+Header ::= SEQUENCE {
+   -- Basic time and sequence values for the message
+   year              DYear           OPTIONAL,
+   timeStamp         MinuteOfTheYear OPTIONAL, 
+   secMark           DSecond         OPTIONAL, 
+   msgIssueRevision  MsgCount        OPTIONAL,         
+   ...  
+   }
+
+
+IntersectionAccessPoint ::= CHOICE {
+   lane       LaneID,
+   approach   ApproachID,
+   connection LaneConnectionID,
+   ...
+   }
+
+
+IntersectionGeometry ::= SEQUENCE {
+   name        DescriptiveName OPTIONAL, 
+                            -- For debug use only
+   id          IntersectionReferenceID,  
+                            -- A globally unique value set, 
+                            -- consisting of a regionID and 
+                            -- intersection ID assignment
+   revision    MsgCount,    
+
+   -- Required default values about lane descriptions follow
+   refPoint    Position3D,  -- The reference from which subsequent 
+                            -- data points are offset until a new
+                            -- point is used. 
+   laneWidth   LaneWidth OPTIONAL,   
+                            -- Reference width used by all subsequent 
+                            -- lanes unless a new width is given  
+   speedLimits SpeedLimitList OPTIONAL, 
+                            -- Reference regulatory speed limits
+                            -- used by all subsequent 
+                            -- lanes unless a new speed is given 
+                            -- See Section 11 for converting and 
+                            -- translating speed expressed in mph 
+                            -- into units of m/s
+   -- Complete details regarding each lane type in this intersection
+   laneSet     LaneList,    -- Data about one or more lanes
+                            -- (all lane data is found here)
+   
+   -- Data describing how to use and request preemption and
+   -- priority services from this intersection (if supported)
+   -- NOTE Additonal data may be added in the next release of the 
+   -- standard at this point to handle this concept
+   preemptPriorityData PreemptPriorityList OPTIONAL, 
+                           -- data about one or more regional
+                           -- preempt or priority zones 
+   
+   regional     SEQUENCE (SIZE(1..4)) OF 
+                RegionalExtension {{REGION.Reg-IntersectionGeometry}} OPTIONAL,
+   ... 
+   }
+
+
+IntersectionGeometryList ::= SEQUENCE (SIZE(1..32)) OF IntersectionGeometry
+
+   
+IntersectionReferenceID ::= SEQUENCE {
+   region  RoadRegulatorID OPTIONAL,
+           -- a globally unique regional assignment value
+           -- typical assigned to a regional DOT authority
+           -- the value zero shall be used for testing needs
+   id      IntersectionID
+           -- a unique mapping to the intersection
+           -- in question within the above region of use
+   }
+
+   
+IntersectionState ::= SEQUENCE {
+   name         DescriptiveName OPTIONAL, 
+                -- human readable name for intersection  
+                -- to be used only in debug mode
+   id           IntersectionReferenceID,  
+                -- A globally unique value set, consisting of a 
+                -- regionID and intersection ID assignment
+                -- provides a unique mapping to the 
+                -- intersection MAP in question
+                -- which provides complete location 
+                -- and approach/move/lane data
+   revision     MsgCount,    
+   status       IntersectionStatusObject,
+                -- general status of the controller(s)
+   moy          MinuteOfTheYear OPTIONAL,
+                -- Minute of current UTC year
+                -- used only with messages to be archived 
+   timeStamp    DSecond OPTIONAL, 
+                -- the mSec point in the current UTC minute that
+                -- this message was constructed
+   enabledLanes EnabledLaneList OPTIONAL,  
+                -- a list of lanes where the RevocableLane bit 
+                -- has been set which are now active and 
+                -- therefore part of the current intersection
+   states       MovementList,
+                -- Each Movement is given in turn
+                -- and contains its signal phase state, 
+                -- mapping to the lanes it applies to, and
+                -- point in time it will end, and it
+                -- may contain both active and future states 
+   maneuverAssistList  ManeuverAssistList OPTIONAL,
+                -- Assist data
+   
+   regional     SEQUENCE (SIZE(1..4)) OF 
+                RegionalExtension {{REGION.Reg-IntersectionState}} OPTIONAL,
+   ... 
+   }
+
+   
+IntersectionStateList ::= SEQUENCE (SIZE(1..32)) OF  IntersectionState
+
+
+ExitService ::= SEQUENCE (SIZE(1..16)) OF SEQUENCE {
+  item CHOICE    {
+       itis   ITIS.ITIScodes,
+       text   ITIStextPhrase
+       }  
+  }
+
+
+GenericSignage ::= SEQUENCE (SIZE(1..16)) OF SEQUENCE {
+  item CHOICE    {
+       itis   ITIS.ITIScodes,
+       text   ITIStextPhrase
+       }  
+  }
+
+
+SpeedLimit ::= SEQUENCE (SIZE(1..16)) OF SEQUENCE {
+  item CHOICE    {
+       itis   ITIS.ITIScodes,
+       text   ITIStextPhrase
+       }  
+  }
+
+
+WorkZone ::= SEQUENCE (SIZE(1..16)) OF SEQUENCE {
+  item CHOICE    {
+       itis   ITIS.ITIScodes,
+       text   ITIStextPhrase
+       }  
+  }
+
+
+J1939data ::= SEQUENCE {
+   -- Tire conditions by tire
+   tires                    TireDataList              OPTIONAL,
+   -- Vehicle Weights by axle
+   axles                    AxleWeightList            OPTIONAL,      
+   trailerWeight            TrailerWeight             OPTIONAL,     
+   cargoWeight              CargoWeight               OPTIONAL, 
+   steeringAxleTemperature  SteeringAxleTemperature   OPTIONAL, 
+   driveAxleLocation        DriveAxleLocation         OPTIONAL, 
+   driveAxleLiftAirPressure DriveAxleLiftAirPressure  OPTIONAL, 
+   driveAxleTemperature     DriveAxleTemperature      OPTIONAL, 
+   driveAxleLubePressure    DriveAxleLubePressure     OPTIONAL, 
+   steeringAxleLubePressure SteeringAxleLubePressure  OPTIONAL, 
+   ...
+   }   
+
+
+TireDataList ::= SEQUENCE (SIZE(1..16)) OF TireData 
+
+
+TireData ::= SEQUENCE {
+      location              TireLocation              OPTIONAL, 
+      pressure              TirePressure              OPTIONAL, 
+      temp                  TireTemp                  OPTIONAL, 
+      wheelSensorStatus     WheelSensorStatus         OPTIONAL, 
+      wheelEndElectFault    WheelEndElectFault        OPTIONAL, 
+      leakageRate           TireLeakageRate           OPTIONAL, 
+      detection             TirePressureThresholdDetection OPTIONAL, 
+      ...
+      }
+
+AxleWeightList ::= SEQUENCE (SIZE(1..16)) OF AxleWeightSet
+
+AxleWeightSet ::= SEQUENCE {
+      location              AxleLocation              OPTIONAL, 
+      weight                AxleWeight                OPTIONAL, 
+      ...
+      }
+
+
+LaneAttributes ::= SEQUENCE {
+   directionalUse  LaneDirection,      -- directions of lane use
+   sharedWith      LaneSharing,        -- co-users of the lane path
+   laneType        LaneTypeAttributes, -- specific lane type data
+   regional        RegionalExtension {{REGION.Reg-LaneAttributes}} OPTIONAL
+   }
+
+
+LaneDataAttribute ::= CHOICE {
+    -- Segment attribute types and the data needed for each
+    pathEndPointAngle        DeltaAngle,  
+                             -- adjusts final point/width slant
+                             -- of the lane to align with the stop line
+    laneCrownPointCenter     RoadwayCrownAngle,  
+                             -- sets the canter of the road bed      
+                             -- from centerline point
+    laneCrownPointLeft       RoadwayCrownAngle,  
+                             -- sets the canter of the road bed
+                             -- from left edge
+    laneCrownPointRight      RoadwayCrownAngle,  
+                             -- sets the canter of the road bed
+                             -- from right edge
+    laneAngle                MergeDivergeNodeAngle,  
+                             -- the angle or direction of another lane
+                             -- this is required to support Japan style
+                             -- when a merge point angle is required
+    speedLimits              SpeedLimitList,
+                             -- Reference regulatory speed limits
+                             -- used by all segments
+   
+    -- Add others as needed, in regional space
+    regional  SEQUENCE (SIZE(1..4)) OF 
+              RegionalExtension {{REGION.Reg-LaneDataAttribute}}, 
+    ...
+    }
+
+
+LaneDataAttributeList ::= SEQUENCE (SIZE(1..8)) OF LaneDataAttribute
+
+
+LaneList ::= SEQUENCE (SIZE(1..255)) OF GenericLane
+
+
+LaneTypeAttributes ::= CHOICE {
+   vehicle        LaneAttributes-Vehicle,        -- motor vehicle lanes
+   crosswalk      LaneAttributes-Crosswalk,      -- pedestrian crosswalks
+   bikeLane       LaneAttributes-Bike,           -- bike lanes
+   sidewalk       LaneAttributes-Sidewalk,       -- pedestrian sidewalk paths
+   median         LaneAttributes-Barrier,        -- medians & channelization
+   striping       LaneAttributes-Striping,       -- roadway markings
+   trackedVehicle LaneAttributes-TrackedVehicle, -- trains and trolleys
+   parking        LaneAttributes-Parking,        -- parking and stopping lanes
+   ...
+   }
+
+
+ManeuverAssistList ::= SEQUENCE (SIZE(1..16)) OF ConnectionManeuverAssist
+
+
+MovementEventList ::= SEQUENCE (SIZE(1..16)) OF MovementEvent
+
+
+MovementEvent ::= SEQUENCE {
+   eventState   MovementPhaseState,
+                -- Consisting of:
+                -- Phase state (the basic 11 states)
+                -- Directional, protected, or permissive state
+   
+   timing       TimeChangeDetails OPTIONAL,
+                -- Timing Data in UTC time stamps for event
+                -- includes start and min/max end times of phase
+                -- confidence and estimated next occurrence
+   
+   speeds       AdvisorySpeedList OPTIONAL,
+                -- various speed advisories for use by
+                -- general and specific types of vehicles
+                -- supporting green-wave and other flow needs
+                -- See Section 11 for converting and translating 
+                -- speed expressed in mph into units of m/s
+
+   regional     SEQUENCE (SIZE(1..4)) OF 
+                RegionalExtension {{REGION.Reg-MovementEvent}} OPTIONAL,
+   ...  
+   }
+
+
+MovementList ::= SEQUENCE (SIZE(1..255)) OF MovementState
+
+
+MovementState ::= SEQUENCE {
+   movementName       DescriptiveName OPTIONAL,
+                      -- uniquely defines movement by name   
+                      -- human readable name for intersection  
+                      -- to be used only in debug mode
+   signalGroup        SignalGroupID,    
+                      -- the group id is used to map to lists 
+                      -- of lanes (and their descriptions) 
+                      -- which this MovementState data applies to 
+                      -- see comments in the Remarks for usage details 
+   state-time-speed   MovementEventList,   
+                      -- Consisting of sets of movement data with:
+                      -- a)  SignalPhaseState
+                      -- b)  TimeChangeDetails,  and 
+                      -- c)  AdvisorySpeeds      (optional )
+                      -- Note one or more of the movement events may be for 
+                      -- a future time and that this allows conveying multiple 
+                      -- predictive phase and movement timing for various uses
+                      -- for the current signal group
+   maneuverAssistList ManeuverAssistList OPTIONAL,
+                      -- This information may also be placed in the 
+                      -- IntersectionState when common information applies to
+                      -- different lanes in the same way
+   regional           SEQUENCE (SIZE(1..4)) OF 
+                      RegionalExtension {{REGION.Reg-MovementState}} OPTIONAL,
+   ...  
+   }
+
+
+Node-LL-24B ::= SEQUENCE {
+   -- ranges of +- 0.0002047 degrees
+   -- ranges of +- 22.634554 meters at the equator
+   lon  OffsetLL-B12,
+   lat  OffsetLL-B12
+   }
+
+
+Node-LL-28B ::= SEQUENCE {
+   -- ranges of +- 0.0008191 degrees
+   -- ranges of +- 90.571389 meters at the equator
+   lon  OffsetLL-B14,
+   lat  OffsetLL-B14
+   }
+
+
+Node-LL-32B ::= SEQUENCE {
+   -- ranges of +- 0.0032767 degrees
+   -- ranges of +- 362.31873 meters at the equator
+   lon  OffsetLL-B16,
+   lat  OffsetLL-B16
+   }
+
+
+Node-LL-36B ::= SEQUENCE {
+   -- ranges of +- 0.0131071 degrees
+   -- ranges of +- 01.449308 Kmeters at the equator
+   lon  OffsetLL-B18,
+   lat  OffsetLL-B18
+   }
+
+
+Node-LL-44B ::= SEQUENCE {
+   -- ranges of +- 0.2097151 degrees
+   -- ranges of +- 23.189096 Kmeters at the equator
+   lon  OffsetLL-B22,
+   lat  OffsetLL-B22
+   }
+
+
+Node-LL-48B ::= SEQUENCE {
+   -- ranges of +- 0.8388607 degrees
+   -- ranges of +- 92.756481 Kmeters at the equator
+   lon  OffsetLL-B24,
+   lat  OffsetLL-B24
+   }
+
+
+Node-LLmD-64b ::= SEQUENCE {
+   lon  Longitude,
+   lat  Latitude
+   }
+
+
+Node-XY-20b ::= SEQUENCE {
+   x  Offset-B10,
+   y  Offset-B10
+   }
+
+
+Node-XY-22b ::= SEQUENCE {
+   x  Offset-B11,
+   y  Offset-B11
+   }
+
+
+Node-XY-24b ::= SEQUENCE {
+   x  Offset-B12,
+   y  Offset-B12
+   }
+
+
+Node-XY-26b ::= SEQUENCE {
+   x  Offset-B13,
+   y  Offset-B13
+   }
+
+
+Node-XY-28b ::= SEQUENCE {
+   x  Offset-B14,
+   y  Offset-B14
+   }
+
+
+Node-XY-32b ::= SEQUENCE {
+   x  Offset-B16,
+   y  Offset-B16
+   }
+
+
+NodeAttributeLLList ::= SEQUENCE (SIZE(1..8)) OF NodeAttributeLL
+
+
+NodeAttributeSetLL ::= SEQUENCE {
+   localNode    NodeAttributeLLList OPTIONAL,
+                -- Attribute states which pertain to this node point
+   disabled     SegmentAttributeLLList OPTIONAL,
+                -- Attribute states which are disabled at this node point
+   enabled      SegmentAttributeLLList OPTIONAL,
+                -- Attribute states which are enabled at this node point
+                -- and which remain enabled until disabled or the lane ends
+   data         LaneDataAttributeList OPTIONAL,
+                -- Attributes which require an additional data values
+                -- some of these are local to the node point, while others
+                -- persist with the provided values until changed
+                -- and this is indicated in each entry
+   dWidth       Offset-B10 OPTIONAL,
+                -- A value added to the current lane width
+                -- at this node and from this node onwards, in 1cm steps
+                -- lane width between nodes are a linear taper between pts
+                -- the value of zero shall not be sent here
+   dElevation   Offset-B10 OPTIONAL,
+                -- A value added to the current Elevation 
+                -- at this node from this node onwards, in 10cm steps
+                -- elevations between nodes are a linear taper between pts
+                -- the value of zero shall not be sent here
+   regional     SEQUENCE (SIZE(1..4)) OF 
+                RegionalExtension {{REGION.Reg-NodeAttributeSetLL}} OPTIONAL,
+   ...
+   }
+
+
+NodeAttributeSetXY ::= SEQUENCE {
+   localNode    NodeAttributeXYList OPTIONAL,
+                -- Attribute states which pertain to this node point
+   disabled     SegmentAttributeXYList OPTIONAL,
+                -- Attribute states which are disabled at this node point
+   enabled      SegmentAttributeXYList OPTIONAL,
+                -- Attribute states which are enabled at this node point
+                -- and which remain enabled until disabled or the lane ends
+   data         LaneDataAttributeList OPTIONAL,
+                -- Attributes which require an additional data values
+                -- some of these are local to the node point, while others
+                -- persist with the provided values until changed
+                -- and this is indicated in each entry
+   dWidth       Offset-B10 OPTIONAL,
+                -- A value added to the current lane width
+                -- at this node and from this node onwards, in 1cm steps
+                -- lane width between nodes are a linear taper between pts
+                -- the value of zero shall not be sent here
+   dElevation   Offset-B10 OPTIONAL,
+                -- A value added to the current Elevation 
+                -- at this node from this node onwards, in 10cm steps
+                -- elevations between nodes are a linear taper between pts
+                -- the value of zero shall not be sent here
+   regional     SEQUENCE (SIZE(1..4)) OF 
+                RegionalExtension {{REGION.Reg-NodeAttributeSetXY}} OPTIONAL,
+   ...
+   }
+
+
+NodeAttributeXYList ::= SEQUENCE (SIZE(1..8)) OF NodeAttributeXY
+
+
+NodeListLL ::= CHOICE {
+   nodes     NodeSetLL,
+             -- a path made up of two or more
+             -- LL node points and any attributes 
+             -- defined in those nodes
+   -- Additional choices will be added in time
+   ...
+   }
+
+
+NodeListXY ::= CHOICE {
+   nodes     NodeSetXY,
+             -- a lane made up of two or more
+             -- XY node points and any attributes 
+             -- defined in those nodes
+   computed  ComputedLane,
+             -- a lane path computed by translating 
+             -- the data defined by another lane
+   ...
+   }
+
+
+NodeLL ::= SEQUENCE {
+   delta       NodeOffsetPointLL,
+               -- A choice of which Lat,Lon offset value to use  
+               -- this includes various delta values as well a regional choices
+   attributes  NodeAttributeSetLL OPTIONAL,
+               -- Any optional Attributes which are needed
+               -- This includes changes to the current lane width and elevation
+   ... 
+   }
+
+
+NodeOffsetPointLL ::= CHOICE {
+   -- Nodes with LL content         Span at the equator when using a zoom of one:
+   node-LL1         Node-LL-24B,    -- within +- 22.634554  meters of last node
+   node-LL2         Node-LL-28B,    -- within +- 90.571389  meters of last node
+   node-LL3         Node-LL-32B,    -- within +- 362.31873  meters of last node
+   node-LL4         Node-LL-36B,    -- within +- 01.449308 Kmeters of last node
+   node-LL5         Node-LL-44B,    -- within +- 23.189096 Kmeters of last node
+   node-LL6         Node-LL-48B,    -- within +- 92.756481 Kmeters of last node
+   node-LatLon      Node-LLmD-64b,  -- node is a full 32b Lat/Lon range
+   regional         RegionalExtension {{REGION.Reg-NodeOffsetPointLL}}
+                                    -- node which follows is of a
+                                    -- regional definition type
+   }
+
+
+NodeOffsetPointXY ::= CHOICE {
+   -- Nodes with X,Y content
+   node-XY1         Node-XY-20b,    -- node is within   5.11m of last node
+   node-XY2         Node-XY-22b,    -- node is within  10.23m of last node
+   node-XY3         Node-XY-24b,    -- node is within  20.47m of last node
+   node-XY4         Node-XY-26b,    -- node is within  40.96m of last node
+   node-XY5         Node-XY-28b,    -- node is within  81.91m of last node
+   node-XY6         Node-XY-32b,    -- node is within 327.67m of last node
+   node-LatLon      Node-LLmD-64b,  -- node is a full 32b Lat/Lon range
+   regional         RegionalExtension {{REGION.Reg-NodeOffsetPointXY}}
+                                    -- node which follows is of a 
+                                    -- regional definition type 
+   }
+
+
+NodeSetLL ::= SEQUENCE (SIZE(2..63)) OF NodeLL
+
+NodeSetXY ::= SEQUENCE (SIZE(2..63)) OF NodeXY
+
+NodeXY ::= SEQUENCE {
+   delta       NodeOffsetPointXY,
+               -- A choice of which X,Y offset value to use  
+               -- this includes various delta values as well a regional choices
+   attributes  NodeAttributeSetXY OPTIONAL,
+               -- Any optional Attributes which are needed
+               -- This includes changes to the current lane width and elevation
+   ... 
+   }
+
+
+ObstacleDetection ::= SEQUENCE {  
+   obDist          ObstacleDistance,        -- Obstacle Distance        
+   obDirect        ObstacleDirection,       -- Obstacle Direction
+   description     ITIS.ITIScodes(523..541) OPTIONAL, 
+                                            -- Uses a limited set of ITIS codes        
+   locationDetails ITIS.GenericLocations OPTIONAL,        
+   dateTime        DDateTime,               -- Time detected
+   vertEvent       VerticalAccelerationThreshold OPTIONAL, 
+                                            -- Any wheels which have 
+                                            -- exceeded the acceleration point
+   ...
+   }
+
+
+OffsetSystem ::= SEQUENCE {
+   scale      Zoom OPTIONAL, 
+   offset     CHOICE {
+      xy        NodeListXY, -- offsets of 1.0 centimeters 
+      ll        NodeListLL  -- offsets of 0.1 microdegrees
+      }
+   } 
+
+
+OverlayLaneList ::= SEQUENCE (SIZE(1..5)) OF LaneID
+   -- The unique ID numbers for any lane object which have
+   -- spatial paths that overlay (run on top of, and not
+   -- simply cross with) the current lane.
+   -- Such as a train path that overlays a motor vehicle
+   -- lane object for a roadway segment.
+
+
+PathHistory ::= SEQUENCE {
+   initialPosition  FullPositionVector    OPTIONAL,
+   currGNSSstatus   GNSSstatus            OPTIONAL,   
+   crumbData  	    PathHistoryPointList,
+   ...
+   }
+
+
+PathHistoryPointList ::= SEQUENCE (SIZE(1..23)) OF PathHistoryPoint
+
+
+PathHistoryPoint ::= SEQUENCE {
+   latOffset       OffsetLL-B18,
+   lonOffset       OffsetLL-B18,
+   elevationOffset VertOffset-B12,  
+   timeOffset      TimeOffset,
+                   -- Offset backwards in time 
+   speed           Speed                 OPTIONAL, 
+                   -- Speed over the reported period
+   posAccuracy     PositionalAccuracy    OPTIONAL, 
+                   -- The accuracy of this value
+   heading         CoarseHeading         OPTIONAL, 
+                   -- overall heading 
+   ...
+   }
+
+
+PathPrediction ::= SEQUENCE {
+   radiusOfCurve RadiusOfCurvature, 
+                 -- LSB units of 10cm
+                 -- straight path to use value of 32767
+   confidence    Confidence, 
+                 -- LSB units of 0.5 percent
+   ...  
+   }
+
+
+PivotPointDescription ::= SEQUENCE {
+   pivotOffset  Offset-B11,   
+                -- This gives a +- 10m range from the edge of the outline
+                -- measured from the edge of the length of this unit
+                -- a negative value is offset to inside the units
+                -- a positive value is offset beyond the unit
+   pivotAngle   Angle,
+                -- Measured between the center-line of this unit 
+                -- and the unit ahead which is pulling it.
+                -- This value is required to project the units relative position
+   pivots       PivotingAllowed,
+                -- true if this unit can rotate about the pivot connection point
+   ...
+   }
+
+
+Position3D ::= SEQUENCE {
+   lat        Latitude,                -- in 1/10th micro degrees
+   long       Longitude,               -- in 1/10th micro degrees
+   elevation  Elevation  OPTIONAL,     -- in 10 cm units
+   regional   SEQUENCE (SIZE(1..4)) OF 
+              RegionalExtension {{REGION.Reg-Position3D}} OPTIONAL,
+   ...
+   }
+
+
+PositionalAccuracy ::= SEQUENCE {
+   -- NMEA-183 values expressed in strict ASN form
+   semiMajor     SemiMajorAxisAccuracy,
+   semiMinor     SemiMinorAxisAccuracy,
+   orientation   SemiMajorAxisOrientation
+   }
+
+
+PositionConfidenceSet ::= SEQUENCE {
+   pos        PositionConfidence, -- for both horizontal directions
+   elevation  ElevationConfidence 
+   }
+
+
+PreemptPriorityList ::= SEQUENCE (SIZE(1..32)) OF SignalControlZone
+
+SignalControlZone ::=  SEQUENCE {
+  zone  RegionalExtension {{REGION.Reg-SignalControlZone}},
+  ...
+  }
+
+
+PrivilegedEvents ::= SEQUENCE {
+   -- CERT SSP Privilege Details
+   sspRights   SSPindex,  
+   -- The active event list
+   event  PrivilegedEventFlags,
+   ...
+   }
+
+
+PropelledInformation ::= CHOICE {
+   human   HumanPropelledType, -- PersonalDeviceUserType would be a aPEDESTRIAN
+   animal  AnimalPropelledType,
+   motor   MotorizedPropelledType,
+   ...
+}          
+
+
+RegionList ::= SEQUENCE (SIZE(1..64)) OF RegionOffsets
+   -- the Position3D ref point (starting point or anchor)
+   -- is found in the outer object.
+
+
+RegionOffsets ::= SEQUENCE {
+   xOffset  OffsetLL-B16,  
+   yOffset  OffsetLL-B16,
+   zOffset  OffsetLL-B16 OPTIONAL
+            -- all in signed values where 
+            -- the LSB is in units of 1 meter  
+   }
+
+
+RegionPointSet ::= SEQUENCE {
+   anchor           Position3D  OPTIONAL, 
+   scale            Zoom OPTIONAL, 
+   nodeList         RegionList,      
+                    -- path details of the regions outline        
+   ...             
+   }
+
+
+RegulatorySpeedLimit ::= SEQUENCE {
+   type        SpeedLimitType, 
+               -- The type of regulatory speed which follows
+   speed       Velocity
+               -- The speed in units of 0.02 m/s
+               -- See Section 11 for converting and translating 
+               -- speed expressed in mph into units of m/s
+   }
+
+
+RequestedItemList ::= SEQUENCE (SIZE(1..32)) OF  RequestedItem
+
+
+RequestorDescription ::= SEQUENCE {
+   id                VehicleID, 
+                     -- The ID used in the BSM or CAM of the requestor
+                     -- This ID is presumed not to change 
+                     -- during the exchange
+   type              RequestorType OPTIONAL,
+                     -- Information regarding all type and class data
+                     -- about the requesting vehicle 
+   position          RequestorPositionVector OPTIONAL,
+                     -- The location of the requesting vehicle
+   name              DescriptiveName OPTIONAL,
+                     -- A human readable name for debugging use
+   -- Support for Transit requests
+   routeName         DescriptiveName OPTIONAL,
+                     -- A string for transit operations use
+   transitStatus     TransitVehicleStatus OPTIONAL,
+                     -- current vehicle state (loading, etc.)
+   transitOccupancy  TransitVehicleOccupancy OPTIONAL,
+                     -- current vehicle occupancy 
+   transitSchedule   DeltaTime OPTIONAL, 
+                     -- current vehicle schedule adherence 
+
+   regional          SEQUENCE (SIZE(1..4)) OF 
+                     RegionalExtension {{REGION.Reg-RequestorDescription}} OPTIONAL,
+   ...
+   }
+
+
+RequestorPositionVector ::= SEQUENCE {
+   position           Position3D,
+   heading            Angle OPTIONAL, 
+   speed              TransmissionAndSpeed OPTIONAL,
+   ...  
+   }
+
+
+RequestorType ::= SEQUENCE {
+   -- Defines who is requesting
+   role         BasicVehicleRole, -- Basic role of this user at this time
+   subrole      RequestSubRole OPTIONAL, -- A local list with role based items 
+    
+   -- Defines what kind of request (a level of importance in the Priority Scheme)
+   request      RequestImportanceLevel OPTIONAL, -- A local list with request items 
+   
+   -- Additional classification details 
+   iso3883      Iso3833VehicleType OPTIONAL,
+   hpmsType     VehicleType OPTIONAL,  -- HPMS classification types
+
+   regional     RegionalExtension {{REGION.Reg-RequestorType}} OPTIONAL,
+   ...
+   }
+
+
+RestrictionClassAssignment ::= SEQUENCE {
+   id       RestrictionClassID,
+            -- the unique value (within an intersection or local region)
+            -- that is assigned to this group of users
+   users    RestrictionUserTypeList 
+            -- The list of user types/classes 
+            -- to which this restriction ID applies
+   }
+
+
+RestrictionClassList ::= SEQUENCE (SIZE(1..254)) OF RestrictionClassAssignment
+
+
+RestrictionUserTypeList ::= SEQUENCE (SIZE(1..16)) OF  RestrictionUserType
+
+
+RestrictionUserType ::= CHOICE {
+   basicType   RestrictionAppliesTo,
+               -- a set of the most commonly used types
+   regional    SEQUENCE (SIZE(1..4)) OF 
+               RegionalExtension {{REGION.Reg-RestrictionUserType}}, 
+   ...
+   }
+
+
+RoadLaneSetList ::= SEQUENCE (SIZE(1..255)) OF GenericLane
+
+
+RoadSegmentList ::= SEQUENCE (SIZE(1..32)) OF RoadSegment
+
+   
+RoadSegmentReferenceID ::= SEQUENCE {
+   region  RoadRegulatorID OPTIONAL,
+           -- a globally unique regional assignment value
+           -- typically assigned to a regional DOT authority
+           -- the value zero shall be used for testing needs
+   id      RoadSegmentID
+           -- a unique mapping to the road segment
+           -- in question within the above region of use
+           -- during its period of assignment and use
+           -- note that unlike intersectionID values, 
+           -- this value can be reused by the region
+   }
+
+   
+RoadSegment ::= SEQUENCE {
+   name        DescriptiveName OPTIONAL,
+   id          RoadSegmentReferenceID,
+                           -- a globally unique value for the segment
+   revision    MsgCount,    
+   -- Required default values about the descriptions to follow
+   refPoint    Position3D, -- the reference from which subsequent
+                           -- data points are offset until a new
+                           -- point is used.
+   laneWidth   LaneWidth OPTIONAL,   
+                            -- Reference width used by all subsequent 
+                            -- lanes unless a new width is given  
+   speedLimits SpeedLimitList OPTIONAL, 
+                            -- Reference regulatory speed limits
+                            -- used by all subsequent 
+                            -- lanes unless a new speed is given   
+                            -- See Section 11 for converting and  
+                            -- translating speed expressed in mph 
+                            -- into units of m/s
+                         
+   -- Data describing disruptions in the RoadSegment
+   -- such as work zones etc will be added here;
+   -- in the US the SAE ITIS codes would be used here
+   -- The details regarding each lane type in the RoadSegment
+   roadLaneSet RoadLaneSetList,   
+  
+   regional    SEQUENCE (SIZE(1..4)) OF 
+               RegionalExtension {{REGION.Reg-RoadSegment}} OPTIONAL,
+   ...
+   }
+
+     
+RoadSignID ::= SEQUENCE {
+   position        Position3D,
+                   -- Location of sign
+   viewAngle       HeadingSlice,
+                   -- Vehicle direction of travel while
+                   -- facing active side of sign
+   mutcdCode       MUTCDCode OPTIONAL,
+                   -- Tag for MUTCD code or "generic sign" 
+   crc             MsgCRC OPTIONAL 
+                   -- Used to provide a check sum
+   }
+
+RTCMheader ::= SEQUENCE {
+   status     GNSSstatus,
+   offsetSet  AntennaOffsetSet
+   }
+
+
+RTCMmessageList ::= SEQUENCE (SIZE(1..5)) OF RTCMmessage
+
+RTCMPackage ::= SEQUENCE {  
+   -- precise antenna position and noise data for a rover
+   rtcmHeader  RTCMheader OPTIONAL,  
+                    
+   -- one or more RTCM messages
+   msgs        RTCMmessageList,
+   ...  
+   }
+
+Sample ::= SEQUENCE {
+   sampleStart  INTEGER(0..255),   --  Sample Starting Point
+   sampleEnd    INTEGER(0..255)    --  Sample Ending Point
+   }
+
+
+SegmentAttributeLLList ::= SEQUENCE (SIZE(1..8)) OF SegmentAttributeLL
+
+
+SegmentAttributeXYList ::= SEQUENCE (SIZE(1..8)) OF SegmentAttributeXY
+
+
+ShapePointSet ::= SEQUENCE {
+   anchor           Position3D     OPTIONAL, 
+   laneWidth        LaneWidth      OPTIONAL, 
+   directionality   DirectionOfUse OPTIONAL, 
+   nodeList         NodeListXY,    -- XY path details of the lane and width           
+   ...             
+   }
+
+SignalRequesterInfo ::= SEQUENCE {
+   -- These three items serve to uniquely identify the requester
+   -- and the specific request to all parties
+   id             VehicleID,
+   request        RequestID,
+   sequenceNumber MsgCount,
+   role           BasicVehicleRole OPTIONAL,
+
+   typeData       RequestorType OPTIONAL, 
+                  -- Used when addition data besides the role
+                  -- is needed, at which point the role entry
+                  -- above is not sent.
+   ...
+   }
+
+SignalRequestList ::= SEQUENCE (SIZE(1..32)) OF SignalRequestPackage
+
+SignalRequestPackage ::= SEQUENCE {
+   request        SignalRequest,
+                  -- The specific request to the intersection
+                  -- contains IntersectionID, request type,
+                  -- requested action (approach/lane request)
+
+   -- The Estimated Time of Arrival (ETA) when the service is requested
+   minute         MinuteOfTheYear OPTIONAL,
+   second         DSecond OPTIONAL,
+   duration       DSecond OPTIONAL,
+                  -- The duration value is used to provide a short interval that
+                  -- extends the ETA so that the requesting vehicle can arrive at 
+                  -- the point of service with uncertainty or with some desired
+                  -- duration of service. This concept can be used to avoid needing 
+                  -- to frequently update the request.
+                  -- The requester must update the ETA and duration values if the
+                  -- period of services extends beyond the duration time.  
+                  -- It should be assumed that if the vehicle does not clear the
+                  -- intersection when the duration is reached, the request will 
+                  -- be cancelled and the intersection will revert to 
+                  -- normal operation.
+   
+   regional       SEQUENCE (SIZE(1..4)) OF 
+                  RegionalExtension {{REGION.Reg-SignalRequestPackage}} OPTIONAL,
+   ...  
+   }
+
+SignalRequest ::= SEQUENCE {
+   -- the unique ID of the target intersection 
+   id            IntersectionReferenceID,  
+   
+   -- The unique requestID used by the requestor
+   requestID     RequestID, 
+  
+   -- The type of request or cancel for priority or preempt use
+   -- when a prior request is canceled, only the requestID is needed
+   requestType   PriorityRequestType,   
+   
+   -- In typical use either an approach or a lane number would
+   -- be given, this indicates the requested 
+   -- path through the intersection to the degree it is known.
+   inBoundLane   IntersectionAccessPoint,       
+                 -- desired entry approach or lane
+   outBoundLane  IntersectionAccessPoint OPTIONAL,       
+                 -- desired exit approach or lane
+                 -- the values zero is used to indicate 
+                 -- intent to stop within the intersection
+   regional      SEQUENCE (SIZE(1..4)) OF 
+                 RegionalExtension {{REGION.Reg-SignalRequest}} OPTIONAL,
+   ...
+   }
+
+SignalStatusList ::= SEQUENCE (SIZE(1..32)) OF SignalStatus
+
+SignalStatusPackageList ::= SEQUENCE (SIZE(1..32)) OF SignalStatusPackage
+
+SignalStatusPackage ::= SEQUENCE {
+   -- The party that made the initial SRM request
+   requester    SignalRequesterInfo OPTIONAL,
+   -- The lanes or approaches used in the request
+   inboundOn    IntersectionAccessPoint, -- estimated lane / approach of vehicle
+   outboundOn   IntersectionAccessPoint OPTIONAL,
+
+   -- The Estimated Time of Arrival (ETA) when the service is requested
+   -- This data echos the data of the request 
+   minute       MinuteOfTheYear OPTIONAL,
+   second       DSecond OPTIONAL,
+      duration     DSecond OPTIONAL,
+
+   -- the SRM status for this request
+   status       PrioritizationResponseStatus,
+                -- Status of request, this may include rejection
+
+   regional     SEQUENCE (SIZE(1..4)) OF 
+                RegionalExtension {{REGION.Reg-SignalStatusPackage}} OPTIONAL,
+   ...  
+   }
+
+
+SignalStatus ::= SEQUENCE {
+   sequenceNumber MsgCount,
+                  -- changed whenever the below contents have change
+   id             IntersectionReferenceID,
+                  -- this provides a unique mapping to the 
+                  -- intersection map in question
+                  -- which provides complete location 
+                  -- and approach/movement/lane data
+                  -- as well as zones for priority/preemption
+   sigStatus      SignalStatusPackageList,
+                  -- a list of detailed status containing all
+                  -- priority or preemption state data, both
+                  -- active and pending, and who requested it
+                  -- requests which are denied are also listed
+                  -- here for a short period of time
+   regional       SEQUENCE (SIZE(1..4)) OF 
+                  RegionalExtension {{REGION.Reg-SignalStatus}} OPTIONAL,
+   ...  
+   }
+
+
+SnapshotDistance ::= SEQUENCE {
+   distance1   GrossDistance,   -- meters
+   speed1      GrossSpeed,      -- meters/second
+   distance2   GrossDistance,   -- meters
+   speed2      GrossSpeed       -- meters/second
+   }
+
+
+Snapshot ::= SEQUENCE {
+   thePosition  FullPositionVector,          
+                -- data of the position and speed, 
+   safetyExt    VehicleSafetyExtensions OPTIONAL, 
+   dataSet      VehicleStatus           OPTIONAL,  
+                -- a sequence of data frames
+                -- which encodes the data
+   ...  
+   }
+
+
+SnapshotTime ::= SEQUENCE {
+   speed1  GrossSpeed,     -- meters/sec - the instantaneous speed  
+                           -- when the calculation is performed
+   time1   SecondOfTime,   -- in seconds
+   speed2  GrossSpeed,     -- meters/sec - the instantaneous speed 
+                           -- when the calculation is performed
+   time2   SecondOfTime    -- in seconds
+   }
+
+
+SpecialVehicleExtensions ::= SEQUENCE {
+   -- The content below requires SSP permissions to transmit
+
+   -- The entire EVA message has been reduced to these items
+   vehicleAlerts  EmergencyDetails OPTIONAL,
+   -- Description or Direction from an emergency vehicle
+   description    EventDescription  OPTIONAL, -- short ITIS description
+   
+   -- Trailers for both passenger vehicles and heavy trucks
+   trailers       TrailerData OPTIONAL,
+
+   -- HAZMAT and Cargo details to be added in a future revision
+
+   -- Wideload, oversized load to be added in a future revision
+
+   ...
+   }
+
+
+SpeedandHeadingandThrottleConfidence ::= SEQUENCE {
+   heading   HeadingConfidence,    
+   speed     SpeedConfidence,      
+   throttle  ThrottleConfidence    
+   }
+
+
+SpeedLimitList ::= SEQUENCE (SIZE(1..9)) OF RegulatorySpeedLimit
+
+
+SpeedProfileMeasurementList ::= SEQUENCE (SIZE(1..20)) OF SpeedProfileMeasurement
+
+SpeedProfile ::= SEQUENCE {
+   -- Composed of set of measured average speeds
+   speedReports SpeedProfileMeasurementList,  
+   ...
+   }
+
+
+SupplementalVehicleExtensions ::= SEQUENCE {
+   -- Note that VehicleEventFlags, ExteriorLights, 
+   -- PathHistory, and PathPrediction are in VehicleSafetyExtensions 
+
+   -- Vehicle Type Classification Data
+   classification   BasicVehicleClass        OPTIONAL,
+                    -- May be required to be present for non passenger vehicles
+   classDetails     VehicleClassification    OPTIONAL,
+   vehicleData      VehicleData              OPTIONAL,
+
+   -- Various V2V Probe Data
+   weatherReport    WeatherReport            OPTIONAL, 
+   weatherProbe     WeatherProbe             OPTIONAL, 
+
+   -- Detected Obstacle data
+   obstacle         ObstacleDetection        OPTIONAL,
+
+   -- Disabled Vehicle Report
+   status           DisabledVehicle          OPTIONAL,
+   
+   -- Oncoming lane speed reporting
+   speedProfile     SpeedProfile             OPTIONAL, 
+
+   -- Raw GNSS measurements
+   theRTCM          RTCMPackage              OPTIONAL, 
+
+   regional  SEQUENCE (SIZE(1..4)) OF 
+             RegionalExtension {{REGION.Reg-SupplementalVehicleExtensions}} OPTIONAL,
+   ...
+
+   }
+
+
+TimeChangeDetails ::= SEQUENCE {
+   startTime   TimeMark           OPTIONAL,
+               -- When this phase 1st started
+   minEndTime  TimeMark,
+               -- Expected shortest end time
+   maxEndTime  TimeMark           OPTIONAL,
+               -- Expected longest end time
+   
+   likelyTime  TimeMark           OPTIONAL,
+               -- Best predicted value based on other data              
+   confidence  TimeIntervalConfidence OPTIONAL,
+               -- Applies to above time element only
+   
+   nextTime    TimeMark           OPTIONAL
+               -- A rough estimate of time when 
+               -- this phase may next occur again
+               -- used to support various ECO driving power 
+               -- management needs.
+   }
+
+
+TrailerData ::= SEQUENCE {
+   -- CERT SSP Privilege Details
+   sspRights   SSPindex, -- index to CERT rights
+
+   -- Offset connection point details from the 
+   -- hauling vehicle to the first trailer unit
+   connection  PivotPointDescription,
+
+   -- One of more Trailer or Dolly Descriptions 
+   -- (each called a unit)
+   units       TrailerUnitDescriptionList,
+
+   ...
+   }
+
+TrailerHistoryPointList ::= SEQUENCE (SIZE(1..23)) OF TrailerHistoryPoint
+
+TrailerHistoryPoint ::= SEQUENCE {
+   pivotAngle       Angle,
+                    -- angle with respect to the lead unit
+   timeOffset       TimeOffset,
+                    -- offset backwards in time 
+   -- Position relative to the hauling Vehicle
+   positionOffset   Node-XY-24b, 
+   elevationOffset  VertOffset-B07 OPTIONAL,   
+   heading          CoarseHeading OPTIONAL, 
+                    -- overall heading 
+   ...
+   }
+
+
+TrailerUnitDescriptionList ::= SEQUENCE (SIZE(1..8)) OF TrailerUnitDescription
+
+
+TrailerUnitDescription ::= SEQUENCE {
+   isDolly          IsDolly, -- if false this is a trailer
+   width            VehicleWidth,   
+   length           VehicleLength,  
+   height           VehicleHeight OPTIONAL,
+   mass             TrailerMass   OPTIONAL,
+   bumperHeights    BumperHeights OPTIONAL,
+   centerOfGravity  VehicleHeight OPTIONAL,
+   -- The front pivot point of the unit
+   frontPivot       PivotPointDescription,
+   -- The rear pivot point connecting to the next element, 
+   -- if present and used (implies another unit is connected)
+   rearPivot        PivotPointDescription OPTIONAL,
+
+   -- Rear wheel pivot point center-line offset
+   -- measured from the rear of the above length
+   rearWheelOffset  Offset-B12 OPTIONAL,   
+                    -- the effective center-line of the wheel set
+
+   -- Current Position relative to the hauling Vehicle
+   positionOffset   Node-XY-24b, 
+   elevationOffset  VertOffset-B07 OPTIONAL,   
+   
+   -- Past Position history relative to the hauling Vehicle
+   crumbData  	    TrailerHistoryPointList OPTIONAL, 
+   ...
+   }
+
+
+TransmissionAndSpeed ::= SEQUENCE {
+   transmisson   TransmissionState,
+   speed         Velocity
+   }
+
+
+TravelerDataFrameList ::= SEQUENCE (SIZE(1..8)) OF TravelerDataFrame
+
+
+TravelerDataFrame ::= SEQUENCE {
+   -- Part I, Frame header
+   sspTimRights    SSPindex,  
+   frameType   TravelerInfoType,  -- (enum, advisory or road sign)
+   msgId CHOICE {
+         furtherInfoID   FurtherInfoID, -- links to ATIS msg
+         roadSignID      RoadSignID     -- an ID to other data
+         },
+   startYear   DYear OPTIONAL,  -- only if needed
+   startTime   MinuteOfTheYear,
+   duratonTime MinutesDuration,
+   priority    SignPrority,
+  
+   -- Part II, Applicable Regions of Use
+   sspLocationRights  SSPindex,  
+   regions SEQUENCE (SIZE(1..16)) OF GeographicalPath,
+
+   -- Part III, Content
+   sspMsgRights1    SSPindex,  -- allowed message types
+   sspMsgRights2    SSPindex,  -- allowed message content
+   content  CHOICE {
+            advisory     ITIS.ITIScodesAndText,           
+                         -- typical ITIS warnings
+            workZone     WorkZone,       
+                         -- work zone signs and directions
+            genericSign  GenericSignage, 
+                         -- MUTCD signs and directions
+            speedLimit   SpeedLimit,     
+                         -- speed limits and cautions
+            exitService  ExitService     
+                         -- roadside avaiable services
+            -- other types may be added in future revisions
+            },   
+   url     URL-Short OPTIONAL,  -- May link to image or other content
+   ...
+   }
+
+
+ValidRegion ::= SEQUENCE {
+   direction         HeadingSlice,
+                     -- field of view over which this applies,
+   extent            Extent OPTIONAL,  
+                     -- the spatial distance over which this
+                     -- message applies and should be presented 
+                     -- to the driver
+   area    CHOICE  {
+      shapePointSet  ShapePointSet,
+                     -- A short road segment
+      circle         Circle,
+                     -- A point and radius
+      regionPointSet RegionPointSet 
+                     -- Wide area enclosed regions
+      }
+   }
+
+
+VehicleClassification ::= SEQUENCE {
+   -- Composed of the following elements:
+
+   -- The 'master' DSRC list used when space is limited
+   keyType         BasicVehicleClass OPTIONAL,
+
+   -- Types used in the MAP/SPAT/SSR/SRM exchanges 
+   role            BasicVehicleRole OPTIONAL, -- Basic CERT role at a given time
+   iso3883         Iso3833VehicleType OPTIONAL,
+   hpmsType        VehicleType OPTIONAL,  -- HPMS classification types
+   
+   -- ITIS types for classes of vehicle and agency
+   vehicleType     ITIS.VehicleGroupAffected OPTIONAL,      
+   responseEquip   ITIS.IncidentResponseEquipment OPTIONAL, 
+   responderType   ITIS.ResponderGroupAffected OPTIONAL,    
+
+   -- Fuel types for vehicles
+   fuelType        FuelType OPTIONAL,      
+
+   regional        SEQUENCE (SIZE(1..4)) OF 
+                   RegionalExtension {{REGION.Reg-VehicleClassification}} OPTIONAL,
+   ...
+   }
+
+
+VehicleData ::= SEQUENCE {    
+   -- Values for width and length are sent in BSM part I 
+   height        VehicleHeight   OPTIONAL,
+   bumpers       BumperHeights   OPTIONAL,
+   mass          VehicleMass     OPTIONAL,
+   trailerWeight TrailerWeight   OPTIONAL,
+   ...
+   }
+
+
+VehicleIdent ::= SEQUENCE {
+   name           DescriptiveName OPTIONAL,
+                  -- a human readable name for debugging use
+   vin            VINstring OPTIONAL,
+                  -- vehicle VIN value
+   ownerCode      IA5String(SIZE(1..32)) OPTIONAL,
+                  -- vehicle owner code 
+   id             VehicleID OPTIONAL, 
+                  -- same value used in the BSM
+      
+   vehicleType    VehicleType  OPTIONAL, 
+   vehicleClass   CHOICE {
+                     vGroup   ITIS.VehicleGroupAffected,
+                     rGroup   ITIS.ResponderGroupAffected,
+                     rEquip   ITIS.IncidentResponseEquipment  
+                  } OPTIONAL, 
+   ...  
+   }
+
+
+VehicleID ::= CHOICE {
+   entityID     TemporaryID,
+   stationID    StationID
+   }
+
+
+VehicleSafetyExtensions ::= SEQUENCE {
+   events             VehicleEventFlags OPTIONAL,
+   pathHistory        PathHistory       OPTIONAL, 
+   pathPrediction     PathPrediction    OPTIONAL,
+   lights             ExteriorLights    OPTIONAL,                       
+   ...
+   }
+
+
+VehicleSize ::= SEQUENCE {
+   width     VehicleWidth,
+   length    VehicleLength
+   }
+
+
+VehicleStatusRequest ::= SEQUENCE {
+   dataType             VehicleStatusDeviceTypeTag, 
+   subType              INTEGER (1..15)   OPTIONAL, 
+   sendOnLessThenValue  INTEGER (-32767..32767) OPTIONAL, 
+   sendOnMoreThenValue  INTEGER (-32767..32767) OPTIONAL, 
+   sendAll              BOOLEAN OPTIONAL, 
+   ... 
+   }
+
+
+VehicleStatusRequestList ::= SEQUENCE (SIZE(1..32)) OF VehicleStatusRequest
+
+
+VehicleStatus ::= SEQUENCE { 
+   lights          ExteriorLights OPTIONAL,                 -- Exterior Lights
+   lightBar        LightbarInUse  OPTIONAL,                 -- PS Lights
+   
+   wipers          WiperSet OPTIONAL,                      -- Wipers
+   
+   brakeStatus     BrakeSystemStatus OPTIONAL, 
+                                                            -- Braking Data
+   brakePressure   BrakeAppliedPressure  OPTIONAL,          -- Braking Pressure
+   roadFriction    CoefficientOfFriction OPTIONAL,          -- Roadway Friction 
+   
+      
+   sunData         SunSensor             OPTIONAL,          -- Sun Sensor        
+   rainData        RainSensor            OPTIONAL,          -- Rain Sensor        
+   airTemp         AmbientAirTemperature OPTIONAL,          -- Air Temperature    
+   airPres         AmbientAirPressure    OPTIONAL,          -- Air Pressure
+   
+   steering   SEQUENCE {
+         angle      SteeringWheelAngle,   
+         confidence SteeringWheelAngleConfidence   OPTIONAL,    
+         rate       SteeringWheelAngleRateOfChange OPTIONAL,   
+         wheels     DrivingWheelAngle              OPTIONAL
+         } OPTIONAL,                               -- steering data
+   
+   accelSets  SEQUENCE {
+         accel4way       AccelerationSet4Way           OPTIONAL, 
+         vertAccelThres  VerticalAccelerationThreshold OPTIONAL, 
+                                                   -- Wheel which has 
+                                                   -- exceeded acceleration point
+         yawRateCon      YawRateConfidence             OPTIONAL, 
+                                                   -- Yaw Rate Confidence
+         hozAccelCon     AccelerationConfidence        OPTIONAL,     
+                                                   -- Acceleration Confidence 
+         confidenceSet   ConfidenceSet                 OPTIONAL
+                                                   -- general ConfidenceSet 
+         } OPTIONAL, 
+                                  
+   
+   object     SEQUENCE {
+         obDist          ObstacleDistance,          -- Obstacle Distance        
+         obDirect        Angle,                     -- Obstacle Direction        
+         dateTime        DDateTime                  -- time detected
+         } OPTIONAL,                                -- detected Obstacle data
+   
+   
+   
+   fullPos         FullPositionVector OPTIONAL,     -- complete set of time and
+                                                    -- position, speed, heading
+   throttlePos     ThrottlePosition OPTIONAL,
+   speedHeadC      SpeedandHeadingandThrottleConfidence OPTIONAL,    
+   speedC          SpeedConfidence OPTIONAL,
+   
+   vehicleData   SEQUENCE {    
+         height        VehicleHeight,
+         bumpers       BumperHeights,
+         mass          VehicleMass,
+         trailerWeight TrailerWeight,
+         type          VehicleType 
+         -- values for width and length are sent in BSM part I as well. 
+         } OPTIONAL,                            -- vehicle data
+   
+   vehicleIdent   VehicleIdent OPTIONAL,        -- common vehicle identity data
+ 
+   j1939data      J1939data OPTIONAL,           -- Various SAE J1938 data items
+     
+   weatherReport SEQUENCE {    
+         isRaining        NTCIP.EssPrecipYesNo,
+         rainRate         NTCIP.EssPrecipRate       OPTIONAL,
+         precipSituation  NTCIP.EssPrecipSituation  OPTIONAL,
+         solarRadiation   NTCIP.EssSolarRadiation   OPTIONAL,
+         friction         NTCIP.EssMobileFriction   OPTIONAL
+         } OPTIONAL,                                        -- local weather data
+      
+   gnssStatus      GNSSstatus          OPTIONAL,              -- vehicle's GPS
+ 
+   ...          
+   }
+
+
+VerticalOffset ::= CHOICE {
+   -- Vertical Offset
+   -- All below in steps of 10cm above or below the reference ellipsoid
+   offset1         VertOffset-B07,  -- with a range of +-   6.3 meters vertical
+   offset2         VertOffset-B08,  -- with a range of +-  12.7 meters vertical
+   offset3         VertOffset-B09,  -- with a range of +-  25.5 meters vertical
+   offset4         VertOffset-B10,  -- with a range of +-  51.1 meters vertical
+   offset5         VertOffset-B11,  -- with a range of +- 102.3 meters vertical
+   offset6         VertOffset-B12,  -- with a range of +- 204.7 meters vertical
+   elevation       Elevation,       -- with a range of -409.5 to + 6143.9 meters
+   regional        RegionalExtension {{REGION.Reg-VerticalOffset}}  
+                                    -- offset which follows is of a
+                                    -- regional definition type
+   }
+
+
+WeatherProbe ::= SEQUENCE {
+   airTemp      AmbientAirTemperature  OPTIONAL,
+   airPressure  AmbientAirPressure     OPTIONAL,
+   rainRates    WiperSet               OPTIONAL,
+   ...
+   }
+
+
+WeatherReport ::= SEQUENCE {    
+   isRaining        NTCIP.EssPrecipYesNo,
+   rainRate         NTCIP.EssPrecipRate       OPTIONAL,
+   precipSituation  NTCIP.EssPrecipSituation  OPTIONAL,
+   solarRadiation   NTCIP.EssSolarRadiation   OPTIONAL,
+   friction         NTCIP.EssMobileFriction   OPTIONAL,
+   roadFriction     CoefficientOfFriction     OPTIONAL,   
+   ... 
+   }
+
+
+WiperSet ::= SEQUENCE {
+   statusFront    WiperStatus,
+   rateFront      WiperRate,
+   statusRear     WiperStatus      OPTIONAL,
+   rateRear       WiperRate        OPTIONAL
+   }   
+
+   
+   
+
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- Start of entries from table Data_Elements...
+-- This table typically contains data element entries.
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+ 
+
+
+Acceleration ::= INTEGER (-2000..2001) 
+   -- LSB units are 0.01 m/s^2
+   -- the value 2000 shall be used for values greater than 2000     
+   -- the value -2000 shall be used for values less than -2000  
+   -- a value of 2001 shall be used for Unavailable
+
+AccelerationConfidence ::= ENUMERATED {
+   unavailable  (0), -- Not Equipped or data is unavailable
+   accl-100-00  (1), -- 100  meters / second squared
+   accl-010-00  (2), -- 10   meters / second squared
+   accl-005-00  (3), -- 5    meters / second squared
+   accl-001-00  (4), -- 1    meters / second squared
+   accl-000-10  (5), -- 0.1  meters / second squared
+   accl-000-05  (6), -- 0.05 meters / second squared
+   accl-000-01  (7)  -- 0.01 meters / second squared
+   } -- Encoded as a 3 bit value
+
+AdvisorySpeedType ::= ENUMERATED {
+    none       (0),
+    greenwave  (1),
+    ecoDrive   (2),
+    transit    (3),
+    ...  
+    } -- Note: subject to further growth
+
+AllowedManeuvers ::= BIT STRING {
+    -- With bits as defined:
+    -- Allowed maneuvers at path end (stop line)
+    -- All maneuvers with bits not set are therefore prohibited !
+    -- A value of zero shall be used for unknown, indicating no Maneuver
+    maneuverStraightAllowed      (0), 
+                                  -- a Straight movement is allowed in this lane
+    maneuverLeftAllowed          (1),  
+                                 -- a Left Turn movement is allowed in this lane
+    maneuverRightAllowed         (2), 
+                                 -- a Right Turn movement is allowed in this lane
+    maneuverUTurnAllowed         (3), 
+                                 -- a U turn movement is allowed in this lane
+    maneuverLeftTurnOnRedAllowed (4), 
+                                 -- a Stop, and then proceed when safe movement 
+                                 -- is allowed in this lane  
+    maneuverRightTurnOnRedAllowed (5), 
+                                 -- a Stop, and then proceed when safe movement 
+                                 -- is allowed in this lane  
+    maneuverLaneChangeAllowed    (6), 
+                                 -- a movement which changes to an outer lane 
+                                 -- on the egress side is allowed in this lane
+                                 -- (example: left into either outbound lane)
+    maneuverNoStoppingAllowed    (7), 
+                                 -- the vehicle should not stop at the stop line
+                                 -- (example: a flashing green arrow)
+    yieldAllwaysRequired         (8), 
+                                 -- the allowed movements above are not protected 
+                                 -- (example: an permanent yellow condition)
+    goWithHalt                   (9), 
+                                 -- after making a full stop, may proceed
+    caution                      (10), 
+                                 -- proceed past stop line with caution
+    reserved1                    (11)
+                                 -- used to align to 12 Bit Field
+   
+   } (SIZE(12))
+
+AmbientAirPressure ::= INTEGER (0..255) 
+   -- 8 Bits in hPa starting at 580 with a resolution of 
+   -- 2 hPa resulting in a range of 580 to 1088
+
+
+AmbientAirTemperature ::= INTEGER (0..191) -- in deg C with a -40 offset
+    -- The value 191 shall indicate an unknown value
+
+Angle ::= INTEGER (0..28800) 
+   -- LSB of 0.0125 degrees
+   -- A range of 0 to 359.9875 degrees
+
+AnimalPropelledType ::= ENUMERATED {   
+   unavailable         (0),
+   otherTypes          (1), -- any method not listed below
+   animalMounted       (2), -- as in horseback          
+   animalDrawnCarriage (3),
+   ...
+}
+
+AnimalType ::= ENUMERATED { 
+   unavailable    (0), 
+   serviceUse     (1),  -- Includes guide or police animals
+   pet            (2),
+   farm           (3),
+   ...
+   }
+
+AntiLockBrakeStatus ::= ENUMERATED {
+   unavailable (0), -- B'00  Vehicle Not Equipped with ABS Brakes 
+                    --       or ABS Brakes status is unavailable
+   off         (1), -- B'01  Vehicle's ABS are Off
+   on          (2), -- B'10  Vehicle's ABS are On ( but not Engaged )
+   engaged     (3)  -- B'11  Vehicle's ABS control is Engaged on any wheel
+   }
+
+ApproachID ::= INTEGER (0..15) -- zero to be used when valid value is unknown
+
+Attachment ::= ENUMERATED { 
+   unavailable                  (0), -- has some unknown attachment type
+   stroller                     (1),
+   bicycleTrailer               (2),
+   cart                         (3),
+   wheelchair                   (4), 
+   otherWalkAssistAttachments   (5),
+   pet                          (6),
+   ...
+   }
+
+AttachmentRadius ::= INTEGER (0..200) -- In LSB units of one decimeter
+
+AuxiliaryBrakeStatus ::= ENUMERATED {
+   unavailable (0), -- B'00  Vehicle Not Equipped with Aux Brakes 
+                    --       or Aux Brakes status is unavailable
+   off         (1), -- B'01  Vehicle's Aux Brakes are Off
+   on          (2), -- B'10  Vehicle's Aux Brakes are On ( Engaged )
+   reserved    (3)  -- B'11 
+   }
+
+BasicVehicleClass ::= INTEGER (0..255)
+unknownVehicleClass             BasicVehicleClass ::=  0  
+                                -- Not Equipped, Not known or unavailable
+specialVehicleClass             BasicVehicleClass ::=  1  
+                                -- Special use    
+--
+--  Basic Passenger Motor Vehicle Types 
+-- 
+passenger-Vehicle-TypeUnknown   BasicVehicleClass ::=  10 -- default type
+passenger-Vehicle-TypeOther     BasicVehicleClass ::=  11 
+-- various fuel types are handled in another element
+
+--
+-- Light Trucks, Pickup, Van, Panel
+-- 
+lightTruck-Vehicle-TypeUnknown  BasicVehicleClass ::=  20 -- default type
+lightTruck-Vehicle-TypeOther    BasicVehicleClass ::=  21 
+
+--
+-- Trucks, Various axle types, includes HPMS items 
+-- 
+truck-Vehicle-TypeUnknown BasicVehicleClass ::=  25 -- default type
+truck-Vehicle-TypeOther BasicVehicleClass ::=  26 
+truck-axleCnt2  BasicVehicleClass ::=  27 -- Two axle, six tire single units    
+truck-axleCnt3  BasicVehicleClass ::=  28 -- Three axle, single units    
+truck-axleCnt4  BasicVehicleClass ::=  29 -- Four or more axle, single unit    
+truck-axleCnt4Trailer BasicVehicleClass ::=  30 -- Four or less axle, single trailer    
+truck-axleCnt5Trailer BasicVehicleClass ::=  31 -- Five or less axle, single trailer    
+truck-axleCnt6Trailer BasicVehicleClass ::=  32 -- Six or more axle, single trailer    
+truck-axleCnt5MultiTrailer BasicVehicleClass ::=  33 -- Five or less axle, multi-trailer    
+truck-axleCnt6MultiTrailer BasicVehicleClass ::=  34 -- Six axle, multi-trailer    
+truck-axleCnt7MultiTrailer BasicVehicleClass ::=  35 -- Seven or more axle, multi-trailer    
+
+--
+-- Motorcycle Types
+--
+motorcycle-TypeUnknown          BasicVehicleClass ::=  40 -- default type
+motorcycle-TypeOther            BasicVehicleClass ::=  41
+motorcycle-Cruiser-Standard     BasicVehicleClass ::=  42
+motorcycle-SportUnclad          BasicVehicleClass ::=  43
+motorcycle-SportTouring         BasicVehicleClass ::=  44
+motorcycle-SuperSport           BasicVehicleClass ::=  45
+motorcycle-Touring              BasicVehicleClass ::=  46
+motorcycle-Trike                BasicVehicleClass ::=  47 
+motorcycle-wPassengers          BasicVehicleClass ::=  48 -- type not stated
+
+--
+-- Transit Types
+--
+transit-TypeUnknown             BasicVehicleClass ::=  50 -- default type
+transit-TypeOther               BasicVehicleClass ::=  51
+transit-BRT                     BasicVehicleClass ::=  52
+transit-ExpressBus              BasicVehicleClass ::=  53
+transit-LocalBus                BasicVehicleClass ::=  54
+transit-SchoolBus               BasicVehicleClass ::=  55
+transit-FixedGuideway           BasicVehicleClass ::=  56
+transit-Paratransit             BasicVehicleClass ::=  57
+transit-Paratransit-Ambulance   BasicVehicleClass ::=  58
+
+--
+-- Emergency Vehicle Types
+--
+emergency-TypeUnknown            BasicVehicleClass ::=  60 -- default type
+emergency-TypeOther              BasicVehicleClass ::=  61 -- includes federal users
+emergency-Fire-Light-Vehicle     BasicVehicleClass ::=  62
+emergency-Fire-Heavy-Vehicle     BasicVehicleClass ::=  63
+emergency-Fire-Paramedic-Vehicle BasicVehicleClass ::=  64
+emergency-Fire-Ambulance-Vehicle BasicVehicleClass ::=  65
+emergency-Police-Light-Vehicle   BasicVehicleClass ::=  66
+emergency-Police-Heavy-Vehicle   BasicVehicleClass ::=  67
+emergency-Other-Responder        BasicVehicleClass ::=  68
+emergency-Other-Ambulance        BasicVehicleClass ::=  69
+
+--
+-- Other DSRC Equipped Travelers
+--
+otherTraveler-TypeUnknown          BasicVehicleClass ::=  80 -- default type
+otherTraveler-TypeOther            BasicVehicleClass ::=  81
+otherTraveler-Pedestrian           BasicVehicleClass ::=  82
+otherTraveler-Visually-Disabled    BasicVehicleClass ::=  83
+otherTraveler-Physically-Disabled  BasicVehicleClass ::=  84
+otherTraveler-Bicycle              BasicVehicleClass ::=  85
+otherTraveler-Vulnerable-Roadworker BasicVehicleClass ::=  86
+
+--
+-- Other DSRC Equipped Device Types
+--
+infrastructure-TypeUnknown      BasicVehicleClass ::=  90 -- default type
+infrastructure-Fixed            BasicVehicleClass ::=  91
+infrastructure-Movable          BasicVehicleClass ::=  92
+equipped-CargoTrailer           BasicVehicleClass ::=  93
+
+
+BasicVehicleRole ::= ENUMERATED {
+    -- Values used in the EU and in the US
+    basicVehicle     (0), -- Light duty passenger vehicle type
+    publicTransport  (1), -- Used in EU for Transit us
+    specialTransport (2), -- Used in EU (e.g. heavy load)
+    dangerousGoods   (3), -- Used in EU for any HAZMAT
+    roadWork         (4), -- Used in EU for State and Local DOT uses
+    roadRescue       (5), -- Used in EU and in the US to include tow trucks.
+    emergency        (6), -- Used in EU for Police, Fire and Ambulance units
+    safetyCar        (7), -- Used in EU for Escort vehicles
+    -- Begin US unique numbering
+    none-unknown     (8), -- added to follow current SAE style guidelines
+    truck            (9), -- Heavy trucks with additional BSM rights and obligations
+    motorcycle      (10), --
+    roadSideSource  (11), -- For infrastructure generated calls such as
+                          -- fire house, rail infrastructure, roadwork site, etc.
+    police          (12), --
+    fire            (13), --
+    ambulance       (14), -- (does not include private para-transit etc.)
+    dot             (15), -- all roadwork vehicles
+    transit         (16), -- all transit vehicles 
+    slowMoving      (17), -- to also include oversize etc.
+    stopNgo         (18), -- to include trash trucks, school buses and others
+                          -- that routinely disturb the free flow of traffic
+    cyclist         (19), --
+    pedestrian      (20), -- also includes those with mobility limitations
+    nonMotorized    (21), -- other, horse drawn, etc.
+    military        (22), --
+    ...   
+    }  
+
+BrakeAppliedPressure ::= ENUMERATED {
+   unavailable  (0),  -- B'0000 Not Equipped
+                      -- or Brake Pres status is unavailable
+   minPressure  (1),  -- B'0001 Minimum Braking Pressure
+   bkLvl-2      (2),  -- B'0010
+   bkLvl-3      (3),  -- B'0011   
+   bkLvl-4      (4),  -- B'0100  
+   bkLvl-5      (5),  -- B'0101
+   bkLvl-6      (6),  -- B'0110
+   bkLvl-7      (7),  -- B'0111
+   bkLvl-8      (8),  -- B'1000
+   bkLvl-9      (9),  -- B'1001
+   bkLvl-10     (10), -- B'1010
+   bkLvl-11     (11), -- B'1011
+   bkLvl-12     (12), -- B'1100
+   bkLvl-13     (13), -- B'1101
+   bkLvl-14     (14), -- B'1110
+   maxPressure  (15)  -- B'1111 Maximum Braking Pressure
+   }  -- Encoded as a 4 bit value
+
+BrakeAppliedStatus ::= BIT STRING {
+   unavailable (0),  -- When set, the brake applied status is unavailable
+   leftFront   (1),  -- Left Front Active
+   leftRear    (2),  -- Left Rear Active
+   rightFront  (3),  -- Right Front Active
+   rightRear   (4)   -- Right Rear Active
+   } (SIZE (5))
+
+BrakeBoostApplied ::= ENUMERATED {
+   unavailable   (0), -- Vehicle not equipped with brake boost
+                      -- or brake boost data is unavailable
+   off           (1), -- Vehicle's brake boost is off
+   on            (2)  -- Vehicle's brake boost is on (applied)
+   }
+
+BumperHeight ::= INTEGER (0..127) -- in units of 0.01 meters from ground surface.
+
+CoarseHeading ::= INTEGER (0..240)
+   -- Where the LSB is in units of 1.5 degrees 
+   -- over a range of 0~358.5 degrees
+   -- the value 240 shall be used for unavailable
+
+CodeWord ::= OCTET STRING (SIZE(1..16)) 
+   -- any octet string up to 16 octets
+
+CoefficientOfFriction ::= INTEGER (0..50) 
+   -- where 0 = 0.00 micro (frictionless), also used when data is unavailable 
+   -- and  50 = 1.00 micro, in steps of 0.02
+
+Confidence ::= INTEGER (0..200)
+   -- LSB units of 0.5 percent
+
+Count ::= INTEGER (0..32)
+
+DDay ::= INTEGER (0..31)  -- units of days
+
+DeltaAngle ::= INTEGER (-150..150) 
+   -- With an angle range from 
+   -- negative 150 to positive 150 
+   -- in one degree steps where zero is directly
+   -- along the axis or the lane center line as defined by the
+   -- two closest points
+
+DeltaTime ::= INTEGER (-122 .. 121) 
+   -- Supporting a range of +/- 20 minute in steps of 10 seconds
+   -- the value of -121 shall be used when more than -20 minutes
+   -- the value of +120 shall be used when more than +20 minutes
+   -- the value -122 shall be used when the value is unavailable
+
+DescriptiveName ::= IA5String (SIZE(1..63))
+
+DHour ::= INTEGER (0..31) -- units of hours
+
+DirectionOfUse ::= ENUMERATED {
+   unavailable (0), -- unknown or NA, not typically used in valid expressions
+   forward     (1), -- direction of travel follows node ordering 
+   reverse     (2), -- direction of travel is the reverse of node ordering 
+   both        (3)  -- direction of travel allowed in both directions 
+   }
+
+DistanceUnits ::= ENUMERATED {
+   centimeter  (0),  
+   cm2-5       (1), -- Steps of 2.5 centimeters
+   decimeter   (2),
+   meter       (3),
+   kilometer   (4),
+   foot        (5), -- US foot, 0.3048 meters exactly
+   yard        (6), -- three US feet
+   mile        (7)  -- US mile (5280 US feet)
+   }
+
+DMinute ::= INTEGER (0..60) -- units of minutes
+
+DMonth ::= INTEGER (0..12) -- units of months
+
+DOffset ::= INTEGER (-840..840) -- units of minutes from UTC time
+
+DrivenLineOffsetLg ::= INTEGER (-32767..32767) 
+   -- LSB units are 1 cm.
+
+DrivenLineOffsetSm ::= INTEGER (-2047..2047) 
+   -- LSB units are 1 cm.
+
+DrivingWheelAngle ::= INTEGER (-128..127) 
+   -- LSB units of 0.3333 degrees.  
+   -- a range of 42.33 degrees each way
+
+DSecond ::= INTEGER (0..65535) -- units of milliseconds
+
+DSRCmsgID ::= INTEGER (0..32767)
+   -- 
+   -- DER forms, 
+   -- All DER forms are now retired and not to be used
+   -- 
+   reservedMessageId-D               DSRCmsgID ::=  0 --'00'H 
+   alaCarteMessage-D                 DSRCmsgID ::=  1 --'01'H ACM
+   -- alaCarteMessage-D is Retired, not to be used
+   basicSafetyMessage-D              DSRCmsgID ::=  2 --'02'H BSM, heartbeat msg
+   basicSafetyMessageVerbose-D       DSRCmsgID ::=  3 --'03'H For testing only
+   commonSafetyRequest-D             DSRCmsgID ::=  4 --'04'H CSR
+   emergencyVehicleAlert-D           DSRCmsgID ::=  5 --'05'H EVA
+   intersectionCollision-D           DSRCmsgID ::=  6 --'06'H ICA
+   mapData-D                         DSRCmsgID ::=  7 --'07'H MAP, intersections 
+   nmeaCorrections-D                 DSRCmsgID ::=  8 --'08'H NMEA
+   probeDataManagement-D             DSRCmsgID ::=  9 --'09'H PDM
+   probeVehicleData-D                DSRCmsgID ::= 10 --'0A'H PVD
+   roadSideAlert-D                   DSRCmsgID ::= 11 --'0B'H RSA
+   rtcmCorrections-D                 DSRCmsgID ::= 12 --'0C'H RTCM
+   signalPhaseAndTimingMessage-D     DSRCmsgID ::= 13 --'0D'H SPAT
+   signalRequestMessage-D            DSRCmsgID ::= 14 --'0E'H SRM
+   signalStatusMessage-D             DSRCmsgID ::= 15 --'0F'H SSM
+   travelerInformation-D             DSRCmsgID ::= 16 --'10'H TIM
+   uperFrame-D                       DSRCmsgID ::= 17 --'11'H UPER frame
+   
+   --
+   -- UPER forms
+   --
+   mapData                           DSRCmsgID ::=   18 -- MAP, intersections 
+   signalPhaseAndTimingMessage       DSRCmsgID ::=   19 -- SPAT
+   -- Above two entries were adopted in the 2015-04 edition
+   -- Message assignments added in 2015 follow below   
+   basicSafetyMessage                DSRCmsgID ::=   20 -- BSM, heartbeat msg
+   commonSafetyRequest               DSRCmsgID ::=   21 -- CSR
+   emergencyVehicleAlert             DSRCmsgID ::=   22 -- EVA
+   intersectionCollision             DSRCmsgID ::=   23 -- ICA
+   nmeaCorrections                   DSRCmsgID ::=   24 -- NMEA
+   probeDataManagement               DSRCmsgID ::=   25 -- PDM
+   probeVehicleData                  DSRCmsgID ::=   26 -- PVD
+   roadSideAlert                     DSRCmsgID ::=   27 -- RSA
+   rtcmCorrections                   DSRCmsgID ::=   28 -- RTCM
+   signalRequestMessage              DSRCmsgID ::=   29 -- SRM
+   signalStatusMessage               DSRCmsgID ::=   30 -- SSM
+   travelerInformation               DSRCmsgID ::=   31 -- TIM
+   personalSafetyMessage             DSRCmsgID ::=   32 -- PSM
+                     
+   --
+   -- The Below values are reserved for local message testing use
+   -- 
+   testMessage00                     DSRCmsgID ::=  240 -- Hex 0xF0 
+   testMessage01                     DSRCmsgID ::=  241  
+   testMessage02                     DSRCmsgID ::=  242  
+   testMessage03                     DSRCmsgID ::=  243  
+   testMessage04                     DSRCmsgID ::=  244   
+   testMessage05                     DSRCmsgID ::=  245  
+   testMessage06                     DSRCmsgID ::=  246  
+   testMessage07                     DSRCmsgID ::=  247  
+   testMessage08                     DSRCmsgID ::=  248  
+   testMessage09                     DSRCmsgID ::=  249  
+   testMessage10                     DSRCmsgID ::=  250 
+   testMessage11                     DSRCmsgID ::=  251  
+   testMessage12                     DSRCmsgID ::=  252  
+   testMessage13                     DSRCmsgID ::=  253  
+   testMessage14                     DSRCmsgID ::=  254  
+   testMessage15                     DSRCmsgID ::=  255-- Hex 0xFF  
+   --
+   -- All other values are reserved for std use
+   --
+
+Duration ::= INTEGER (0..3600) -- units of seconds
+
+DYear ::= INTEGER (0..4095) -- units of years
+
+ElevationConfidence ::= ENUMERATED {
+   unavailable (0),  -- B'0000  Not Equipped or unavailable
+   elev-500-00 (1),  -- B'0001  (500 m)
+   elev-200-00 (2),  -- B'0010  (200 m)
+   elev-100-00 (3),  -- B'0011  (100 m)
+   elev-050-00 (4),  -- B'0100  (50 m)
+   elev-020-00 (5),  -- B'0101  (20 m)
+   elev-010-00 (6),  -- B'0110  (10 m)
+   elev-005-00 (7),  -- B'0111  (5 m)
+   elev-002-00 (8),  -- B'1000  (2 m)
+   elev-001-00 (9),  -- B'1001  (1 m)
+   elev-000-50 (10), -- B'1010  (50 cm)
+   elev-000-20 (11), -- B'1011  (20 cm)
+   elev-000-10 (12), -- B'1100  (10 cm)
+   elev-000-05 (13), -- B'1101  (5 cm)
+   elev-000-02 (14), -- B'1110  (2 cm)
+   elev-000-01 (15)  -- B'1111  (1 cm)
+   }  -- Encoded as a 4 bit value
+
+Elevation ::= INTEGER (-4096..61439) 
+    -- In units of 10 cm steps above or below the reference ellipsoid
+    -- Providing a range of -409.5 to + 6143.9 meters
+    -- The value -4096 shall be used when Unknown is to be sent
+
+Extent ::= ENUMERATED {
+   useInstantlyOnly     (0),
+   useFor3meters        (1),
+   useFor10meters       (2),
+   useFor50meters       (3),
+   useFor100meters      (4),
+   useFor500meters      (5),
+   useFor1000meters     (6),
+   useFor5000meters     (7),
+   useFor10000meters    (8),
+   useFor50000meters    (9),
+   useFor100000meters   (10),
+   useFor500000meters   (11),
+   useFor1000000meters  (12),
+   useFor5000000meters  (13),
+   useFor10000000meters (14),
+   forever              (15)  -- very wide area
+   }  -- Encoded as a 4 bit value
+
+ExteriorLights ::= BIT STRING { 
+   -- All lights off is indicated by no bits set
+   lowBeamHeadlightsOn       (0), 
+   highBeamHeadlightsOn      (1), 
+   leftTurnSignalOn          (2), 
+   rightTurnSignalOn         (3), 
+   hazardSignalOn            (4), 
+   automaticLightControlOn   (5),
+   daytimeRunningLightsOn    (6), 
+   fogLightOn                (7), 
+   parkingLightsOn           (8) 
+   } (SIZE (9, ...))
+
+   
+FuelType ::= INTEGER (0..15)
+   unknownFuel   FuelType::=  0 -- Gasoline Powered
+   gasoline      FuelType::=  1 
+   ethanol       FuelType::=  2 -- Including blends
+   diesel        FuelType::=  3 -- All types
+   electric      FuelType::=  4  
+   hybrid        FuelType::=  5 -- All types 
+   hydrogen      FuelType::=  6  
+   natGasLiquid  FuelType::=  7 -- Liquefied
+   natGasComp    FuelType::=  8 -- Compressed
+   propane       FuelType::=  9  
+
+
+FurtherInfoID ::= OCTET STRING (SIZE(2))
+   -- a link to any other incident 
+   -- information data that may be available 
+   -- in the normal ATIS incident description 
+   -- or other messages
+
+GNSSstatus ::= BIT STRING {
+   unavailable               (0), -- Not Equipped or unavailable
+   isHealthy                 (1),
+   isMonitored               (2),
+   baseStationType           (3), -- Set to zero if a moving base station,
+                                  -- or if a rover device (an OBU),
+                                  -- set to one if it is a fixed base station 
+   aPDOPofUnder5             (4), -- A dilution of precision greater than 5
+   inViewOfUnder5            (5), -- Less than 5 satellites in view
+   localCorrectionsPresent   (6), -- DGPS type corrections used
+   networkCorrectionsPresent (7)  -- RTK type corrections used
+   } (SIZE(8))
+
+GrossDistance ::= INTEGER (0..1023) -- Units of 1.00 meters
+   -- The value 1023 shall indicate unavailable
+
+GrossSpeed ::= INTEGER (0..31) -- Units of 1.00 m/s
+   -- The value 30 shall be used for speeds of 30 m/s or greater (67.1 mph)
+   -- The value 31 shall indicate that the speed is unavailable
+
+HeadingConfidence ::= ENUMERATED {
+   unavailable   (0), -- B'000  Not Equipped or unavailable
+   prec10deg     (1), -- B'010  10     degrees
+   prec05deg     (2), -- B'011  5      degrees
+   prec01deg     (3), -- B'100  1      degrees
+   prec0-1deg    (4), -- B'101  0.1    degrees
+   prec0-05deg   (5), -- B'110  0.05   degrees
+   prec0-01deg   (6), -- B'110  0.01   degrees
+   prec0-0125deg (7)  -- B'111  0.0125 degrees, aligned with heading LSB
+   }  -- Encoded as a 3 bit value
+
+Heading ::= INTEGER (0..28800) 
+   -- LSB of 0.0125 degrees
+   -- A range of 0 to 359.9875 degrees
+
+HeadingSlice ::= BIT STRING {
+   -- Each bit 22.5 degree starting from 
+   -- North and moving Eastward (clockwise) as one bit
+   -- a value of noHeading means no bits set, while a 
+   -- a value of allHeadings means all bits would be set             
+      
+   from000-0to022-5degrees  (0),   
+   from022-5to045-0degrees  (1),   
+   from045-0to067-5degrees  (2),   
+   from067-5to090-0degrees  (3),   
+   
+   from090-0to112-5degrees  (4),   
+   from112-5to135-0degrees  (5),   
+   from135-0to157-5degrees  (6),   
+   from157-5to180-0degrees  (7),   
+   
+   from180-0to202-5degrees  (8),   
+   from202-5to225-0degrees  (9),   
+   from225-0to247-5degrees  (10),  
+   from247-5to270-0degrees  (11),  
+   
+   from270-0to292-5degrees  (12),  
+   from292-5to315-0degrees  (13),  
+   from315-0to337-5degrees  (14),  
+   from337-5to360-0degrees  (15)  
+   }  (SIZE (16))
+
+IntersectionID ::= INTEGER (0..65535)
+   -- The values zero through 255 are allocated for testing purposes
+   -- Note that the value assigned to an intersection will be
+   -- unique within a given regional ID only
+
+IntersectionStatusObject ::= BIT STRING {
+    manualControlIsEnabled                (0),
+      -- Timing reported is per programmed values, etc. but person
+      -- at cabinet can manually request that certain intervals are
+      -- terminated early (e.g. green).
+    stopTimeIsActivated                   (1),
+      -- And all counting/timing has stopped.
+    failureFlash                          (2), 
+      -- Above to be used for any detected hardware failures, 
+      -- e.g. conflict monitor as well as for police flash 
+    preemptIsActive                       (3),
+    signalPriorityIsActive                (4),   
+	 
+   -- Additional states
+    fixedTimeOperation                    (5),
+      -- Schedule of signals is based on time only 
+      -- (i.e. the state can be calculated)
+    trafficDependentOperation             (6),
+      -- Operation is based on different levels of traffic parameters 
+      -- (requests, duration of gaps or more complex parameters)
+    standbyOperation                      (7),
+      -- Controller: partially switched off or partially amber flashing
+    failureMode                           (8),
+      -- Controller has a problem or failure in operation
+    off                                   (9),
+      -- Controller is switched off
+	 
+   -- Related to MAP and SPAT bindings
+    recentMAPmessageUpdate                (10),
+      -- Map revision with content changes
+    recentChangeInMAPassignedLanesIDsUsed (11),
+      -- Change in MAP's assigned lanes used (lane changes)
+      -- Changes in the active lane list description
+    noValidMAPisAvailableAtThisTime       (12),
+      -- MAP (and various lanes indexes) not available
+    noValidSPATisAvailableAtThisTime      (13)
+      -- SPAT system is not working at this time
+    
+    -- Bits 14,15 reserved at this time and shall be zero
+    } (SIZE(16))
+
+IsDolly ::= BOOLEAN -- When false indicates a trailer unit
+
+Iso3833VehicleType ::= INTEGER (0..100) 
+
+ITIStextPhrase ::= IA5String (SIZE(1..16))
+
+AxleLocation ::= INTEGER (0..255)
+
+AxleWeight ::= INTEGER (0..64255)
+
+CargoWeight ::= INTEGER (0..64255)
+
+DriveAxleLiftAirPressure ::= INTEGER (0..1000)
+
+DriveAxleLocation ::= INTEGER (0..255)
+
+DriveAxleLubePressure ::= INTEGER (0..250)
+
+DriveAxleTemperature ::= INTEGER (-40..210)
+
+SteeringAxleLubePressure ::= INTEGER (0..250)
+
+SteeringAxleTemperature ::= INTEGER (-40..210)
+
+TireLeakageRate ::= INTEGER (0..64255)
+
+TireLocation ::= INTEGER (0..255)
+
+TirePressureThresholdDetection ::= ENUMERATED {
+   noData                (0),  -- B'000'
+   overPressure          (1),  -- B'001' 
+   noWarningPressure     (2),  -- B'010'
+   underPressure         (3),  -- B'011'
+   extremeUnderPressure  (4),  -- B'100'
+   undefined             (5),  -- B'101'
+   errorIndicator        (6),  -- B'110'
+   notAvailable          (7)   -- B'111'
+   }  -- Encoded as a 3 bit value
+
+TirePressure ::= INTEGER (0..250)
+
+TireTemp ::= INTEGER (-8736..55519)
+
+TrailerWeight ::= INTEGER (0..64255)
+
+WheelEndElectFault ::= ENUMERATED {
+   isOk            (0), -- No fault
+   isNotDefined    (1),
+   isError         (2),
+   isNotSupported  (3)
+   }  
+
+WheelSensorStatus ::= ENUMERATED {
+   off           (0), 
+   on            (1),
+   notDefined    (2), 
+   notSupported  (3)
+   }  
+ 
+LaneAttributes-Barrier ::= BIT STRING {
+   -- With bits as defined:
+   median-RevocableLane     (0),
+                            -- this lane may be activated or not based
+                            -- on the current SPAT message contents
+                            -- if not asserted, the lane is ALWAYS present
+   median                   (1),
+   whiteLineHashing         (2),
+   stripedLines             (3),
+   doubleStripedLines       (4),
+   trafficCones             (5),
+   constructionBarrier      (6),
+   trafficChannels          (7),
+   lowCurbs                 (8),
+   highCurbs                (9)
+   -- Bits 10~15 reserved and set to zero
+   } (SIZE (16))
+
+LaneAttributes-Bike ::= BIT STRING {
+   -- With bits as defined:
+   bikeRevocableLane       (0),
+                           -- this lane may be activated or not based
+                           -- on the current SPAT message contents
+                           -- if not asserted, the lane is ALWAYS present
+   pedestrianUseAllowed    (1),
+                           -- The path allows pedestrian traffic, 
+                           -- if not set, this mode is prohibited
+   isBikeFlyOverLane       (2),
+                           -- path of lane is not at grade
+   fixedCycleTime          (3),
+                           -- the phases use preset times
+                           -- i.e. there is not a 'push to cross' button
+   biDirectionalCycleTimes (4),
+                           -- ped walk phases use different SignalGroupID
+                           -- for each direction. The first SignalGroupID
+                           -- in the first Connection represents 'inbound'
+                           -- flow (the direction of travel towards the first 
+                           -- node point) while second SignalGroupID in the 
+                           -- next Connection entry represents the 'outbound'
+                           -- flow. And use of RestrictionClassID entries
+                           -- in the Connect follow this same pattern in pairs.
+   isolatedByBarrier       (5),
+   unsignalizedSegmentsPresent  (6)
+                           -- The lane path consists of one of more segments
+                           -- which are not part of a signal group ID
+
+   -- Bits 7~15 reserved and set to zero
+   } (SIZE (16))
+
+LaneAttributes-Crosswalk ::= BIT STRING { 
+   -- With bits as defined:
+   -- MUTCD provides no suitable "types" to use here
+   crosswalkRevocableLane  (0),
+                           -- this lane may be activated or not based
+                           -- on the current SPAT message contents
+                           -- if not asserted, the lane is ALWAYS present
+   bicyleUseAllowed        (1),
+                           -- The path allows bicycle traffic, 
+                           -- if not set, this mode is prohibited
+   isXwalkFlyOverLane      (2),
+                           -- path of lane is not at grade
+   fixedCycleTime          (3),
+                           -- ped walk phases use preset times
+                           -- i.e. there is not a 'push to cross' button
+   biDirectionalCycleTimes (4),
+                           -- ped walk phases use different SignalGroupID
+                           -- for each direction. The first SignalGroupID
+                           -- in the first Connection represents 'inbound'
+                           -- flow (the direction of travel towards the first 
+                           -- node point) while second SignalGroupID in the 
+                           -- next Connection entry represents the 'outbound'
+                           -- flow. And use of RestrictionClassID entries
+                           -- in the Connect follow this same pattern in pairs.
+   hasPushToWalkButton     (5),
+                           -- Has a demand input
+   audioSupport            (6),
+                           -- audio crossing cues present
+   rfSignalRequestPresent  (7),
+                           -- Supports RF push to walk technologies
+   unsignalizedSegmentsPresent  (8)
+                           -- The lane path consists of one of more segments
+                           -- which are not part of a signal group ID
+   -- Bits 9~15 reserved and set to zero
+   } (SIZE (16))
+
+LaneAttributes-Parking ::= BIT STRING { 
+    -- With bits as defined:
+    -- Parking use details, note that detailed restrictions such as 
+    -- allowed hours are sent by way of ITIS codes in the TIM message
+    parkingRevocableLane         (0),
+                                 -- this lane may be activated or not based
+                                 -- on the current SPAT message contents
+                                 -- if not asserted, the lane is ALWAYS present
+    parallelParkingInUse         (1),
+    headInParkingInUse           (2),
+    doNotParkZone                (3),
+                                 -- used to denote fire hydrants as well as
+                                 -- short disruptions in a parking zone
+    parkingForBusUse             (4),
+    parkingForTaxiUse            (5),
+    noPublicParkingUse           (6)
+                                 -- private parking, as in front of
+                                 -- private property
+   -- Bits 7~15 reserved and set to zero
+   } (SIZE (16))
+
+LaneAttributes-Sidewalk ::= BIT STRING { 
+   -- With bits as defined:
+   sidewalk-RevocableLane  (0),
+                           -- this lane may be activated or not based
+                           -- on the current SPAT message contents
+                           -- if not asserted, the lane is ALWAYS present
+   bicyleUseAllowed        (1),
+                           -- The path allows bicycle traffic, 
+                           -- if not set, this mode is prohibited
+   isSidewalkFlyOverLane   (2),
+                           -- path of lane is not at grade
+   walkBikes               (3)
+                           -- bike traffic must dismount and walk
+   -- Bits 4~15 reserved and set to zero
+   } (SIZE (16))
+
+
+LaneAttributes-Striping ::= BIT STRING { 
+   -- With bits as defined:
+    stripeToConnectingLanesRevocableLane      (0),
+       -- this lane may be activated or not activated based
+       -- on the current SPAT message contents
+       -- if not asserted, the lane is ALWAYS present
+    stripeDrawOnLeft                          (1),
+    stripeDrawOnRight                         (2),
+        -- which side of lane to mark
+    stripeToConnectingLanesLeft               (3),
+    stripeToConnectingLanesRight              (4),
+    stripeToConnectingLanesAhead              (5)
+        -- the stripe type should be
+        -- presented to the user visually
+        -- to reflect stripes in the 
+        -- intersection for the type of
+        -- movement indicated
+   -- Bits 6~15 reserved and set to zero
+   } (SIZE (16))
+
+
+LaneAttributes-TrackedVehicle ::= BIT STRING { 
+   -- With bits as defined:
+   spec-RevocableLane         (0),
+                               -- this lane may be activated or not based
+                               -- on the current SPAT message contents
+                               -- if not asserted, the lane is ALWAYS present
+   spec-commuterRailRoadTrack (1), 
+   spec-lightRailRoadTrack    (2),
+   spec-heavyRailRoadTrack    (3),
+   spec-otherRailType         (4)
+   -- Bits 5~15 reserved and set to zero
+   } (SIZE (16))
+
+
+LaneAttributes-Vehicle ::= BIT STRING {  
+   -- With bits as defined:
+   isVehicleRevocableLane       (0),
+                                 -- this lane may be activated or not based
+                                 -- on the current SPAT message contents
+                                 -- if not asserted, the lane is ALWAYS present
+   isVehicleFlyOverLane         (1),
+                                 -- path of lane is not at grade
+   hovLaneUseOnly               (2),
+   restrictedToBusUse           (3),
+   restrictedToTaxiUse          (4),
+   restrictedFromPublicUse      (5),
+   hasIRbeaconCoverage          (6),
+   permissionOnRequest          (7) -- e.g. to inform about a lane for e-cars
+
+   } (SIZE (8,...))
+
+
+LaneConnectionID ::= INTEGER (0..255)
+
+LaneDirection ::= BIT STRING {
+   -- With bits as defined:
+   -- Allowed directions of travel in the lane object
+   -- All lanes are described from the stop line outwards
+   ingressPath     (0), 
+                   -- travel from rear of path to front 
+                   -- is allowed
+   egressPath      (1)
+                   -- travel from front of path to rear 
+                   -- is allowed
+   -- Notes:  No Travel, i.e. the lane object type does not support
+   --         travel (medians, curbs, etc.) is indicated by not 
+   --         asserting any bit value
+   --         Bi-Directional Travel (such as a ped crosswalk) is 
+   --         indicated by asserting both of the bits
+   } (SIZE (2))
+
+LaneID ::= INTEGER (0..255)
+   -- the value 0 shall be used when the lane ID is
+   -- not available or not known
+   -- the value 255 is reserved for future use
+
+LaneSharing ::= BIT STRING {
+    -- With bits as defined:
+    overlappingLaneDescriptionProvided  (0),
+    -- Assert when another lane object is present to describe the
+    -- path of the overlapping shared lane
+    -- this construct is not used for lane objects which simply cross
+    multipleLanesTreatedAsOneLane       (1),
+    -- Assert if the lane object path and width details represents
+    -- multiple lanes within it that are not further described
+
+    -- Various modes and type of traffic that may share this lane:
+    otherNonMotorizedTrafficTypes       (2), -- horse drawn etc.
+    individualMotorizedVehicleTraffic   (3),
+    busVehicleTraffic                   (4),  
+    taxiVehicleTraffic                  (5),
+    pedestriansTraffic                  (6),
+    cyclistVehicleTraffic               (7),
+    trackedVehicleTraffic               (8),
+    pedestrianTraffic                   (9)
+    } (SIZE (10))
+    -- All zeros would indicate 'not shared' and 'not overlapping'
+
+LaneWidth ::= INTEGER (0..32767) -- units of 1 cm
+
+Latitude ::= INTEGER (-900000000..900000001)  
+   -- LSB = 1/10 micro degree
+   -- Providing a range of plus-minus 90 degrees
+
+LayerID ::= INTEGER (0..100)
+
+LayerType ::= ENUMERATED {
+     none, 
+     mixedContent, -- two or more of the below types
+     generalMapData, 
+     intersectionData, 
+     curveData, 
+     roadwaySectionData, 
+     parkingAreaData, 
+     sharedLaneData,
+     ... 
+     }
+
+LightbarInUse ::= ENUMERATED {
+     unavailable         (0),  -- Not Equipped or unavailable
+     notInUse            (1),  -- none active
+     inUse               (2),  
+     yellowCautionLights (3),  
+     schooldBusLights    (4),  
+     arrowSignsActive    (5),  
+     slowMovingVehicle   (6),   
+     freqStops           (7)   
+     }
+
+Longitude ::= INTEGER (-1799999999..1800000001)  
+   -- LSB = 1/10 micro degree
+   -- Providing a range of plus-minus 180 degrees
+
+Location-quality ::= ENUMERATED {                        
+     loc-qual-bt1m       (0), -- quality better than 1 meter
+     loc-qual-bt5m       (1), -- quality better than 5 meters
+     loc-qual-bt12m      (2), -- quality better than 12.5 meters
+     loc-qual-bt50m      (3), -- quality better than 50 meters
+     loc-qual-bt125m     (4), -- quality better than 125 meters
+     loc-qual-bt500m     (5), -- quality better than 500 meters
+     loc-qual-bt1250m    (6), -- quality better than 1250 meters
+     loc-qual-unknown    (7)  -- quality value unknown
+     } -- 3 bits, appends with loc-tech to make one octet (0..7)
+
+Location-tech ::= ENUMERATED {                        
+     loc-tech-unknown    (0), -- technology type unknown
+     loc-tech-GNSS       (1), -- GNSS technology only
+     loc-tech-DGPS       (2), -- differential GNSS (DGPS) technology
+     loc-tech-RTK        (3), -- differential GNSS (RTK) technology
+     loc-tech-PPP        (4), -- precise point positioning (PPP) technology
+     loc-tech-drGPS      (5), -- dead reckoning system w/GPS
+     loc-tech-drDGPS     (6), -- dead reckoning system w/DGPS
+     loc-tech-dr         (7), -- dead reckoning only
+     loc-tech-nav        (8), -- autonomous navigation system on-board
+     loc-tech-fault      (9), -- feature is not working
+     ...
+     }    
+
+MergeDivergeNodeAngle ::= INTEGER (-180..180) 
+   -- In units of 1.5 degrees from north
+   -- the value -180 shall be used to represent 
+   -- data is not available or unknown
+
+MessageBLOB ::= OCTET STRING (SIZE(10..2000)) 
+    -- Final size range may be further 
+    -- limited by the transport layer used
+
+MinuteOfTheYear ::= INTEGER (0..527040) 
+   -- the value 527040 shall be used for invalid
+
+MinutesDuration ::= INTEGER (0..32000) -- units of minutes
+
+MotorizedPropelledType ::= ENUMERATED {   
+   unavailable         (0),
+   otherTypes          (1), -- any method not listed below
+   wheelChair          (2),
+   bicycle             (3),
+   scooter             (4),
+   selfBalancingDevice (5), -- such as Segway
+   ...
+}
+
+MovementPhaseState ::= ENUMERATED {
+    -- Note that based on the regions and the operating mode not every 
+    -- phase will be used in all transportation modes and that not 
+    -- every phase will be used in all transportation modes
+  
+    unavailable (0), 
+      -- This state is used for unknown or error 
+    dark (1),   
+      -- The signal head is dark (unlit)
+
+   -- Reds
+    stop-Then-Proceed (2), 
+      -- Often called 'flashing red' in US
+      -- Driver Action:                     
+      --   Stop vehicle at stop line. 
+      --   Do not proceed unless it is safe.
+      -- Note that the right to proceed either right or left when 
+      -- it is safe may be contained in the lane description to 
+      -- handle what is called a 'right on red'
+    stop-And-Remain (3),
+      -- e.g. called 'red light' in US
+      -- Driver Action:                     
+      --   Stop vehicle at stop line. 
+      --   Do not proceed.                     
+      -- Note that the right to proceed either right or left when 
+      -- it is safe may be contained in the lane description to 
+      -- handle what is called a 'right on red'
+   
+   -- Greens
+    pre-Movement (4), 
+      -- Not used in the US, red+yellow partly in EU
+      -- Driver Action:                     
+      --   Stop vehicle. 
+      --   Prepare to proceed (pending green)
+      --   (Prepare for transition to green/go)
+    permissive-Movement-Allowed (5), 
+      -- Often called 'permissive green' in US
+      -- Driver Action:                     
+      --   Proceed with caution, 
+      --   must yield to all conflicting traffic 
+      -- Conflicting traffic may be present
+      -- in the intersection conflict area
+    protected-Movement-Allowed (6), 
+      -- Often called 'protected green' in US
+      -- Driver Action:                     
+      --   Proceed, tossing caution to the wind, 
+      --   in indicated (allowed) direction.
+   
+   -- Yellows / Ambers
+   -- The vehicle is not allowed to cross the stop bar if it is possible 
+   -- to stop without danger. 
+    permissive-clearance (7), 
+      -- Often called 'permissive yellow' in US
+      -- Driver Action:                     
+      --   Prepare to stop.
+      --   Proceed if unable to stop,
+      --   Clear Intersection.
+      -- Conflicting traffic may be present
+      -- in the intersection conflict area
+    protected-clearance (8),  
+      -- Often called 'protected yellow' in US
+      -- Driver Action: 
+      --   Prepare to stop.
+      --   Proceed if unable to stop,
+      --   in indicated direction (to connected lane)
+      --   Clear Intersection.
+                    
+    caution-Conflicting-Traffic (9)
+      -- Often called 'flashing yellow' in US
+      -- Often used for extended periods of time
+      -- Driver Action: 
+      --   Proceed with caution, 
+      -- Conflicting traffic may be present
+      -- in the intersection conflict area
+    }
+    -- The above number assignments are not used with UPER encoding
+    -- and are only to be used with DER or implicit encoding
+
+
+MsgCount ::= INTEGER (0..127)
+
+MsgCRC ::= OCTET STRING (SIZE(2)) -- created with the CRC-CCITT polynomial
+
+MultiVehicleResponse ::= ENUMERATED {
+     unavailable   (0), -- Not Equipped or unavailable
+     singleVehicle (1),  
+     multiVehicle  (2),  
+     reserved      (3)  -- for future use
+     }
+		
+MUTCDCode ::= ENUMERATED {
+   none            (0), -- non-MUTCD information 
+   regulatory      (1), -- "R" Regulatory signs
+   warning         (2), -- "W" warning signs
+   maintenance     (3), -- "M" Maintenance and construction 
+   motoristService (4), -- Motorist Services
+   guide           (5), -- "G" Guide signs
+   rec             (6), -- Recreation and Cultural Interest 
+   ...  
+   }   
+
+NMEA-MsgType ::= INTEGER (0..32767)
+
+NMEA-Payload ::= OCTET STRING (SIZE(1..1023))
+
+NMEA-Revision ::= ENUMERATED {
+     unknown       (0), -- default value
+     reserved      (1),
+     rev1          (2),
+     rev2          (3), -- used for 2.x
+     rev3          (4), -- used for 3.x
+     rev4          (5), -- used for 4.x  (NMEA 4.00 Published November 2008)
+     rev5          (6),
+     ...  
+     }
+
+NodeAttributeLL ::= ENUMERATED {
+   -- Various values which pertain only to the current node point
+   
+   -- General Items
+   reserved,  
+   stopLine,             -- point where a mid-path stop line exists
+                         -- See also 'do not block' for segments
+
+   -- Path finish details 
+   roundedCapStyleA,      -- Used to control final path rounded end shape
+                          -- with edge of curve at final point in a circle
+   roundedCapStyleB,      -- Used to control final path rounded end shape
+                          -- with edge of curve extending 50% of width past
+                          -- final point in a circle
+   
+   -- Topography Points (items with no concept of a distance along the path)
+   mergePoint,           -- Japan merge with 1 or more lanes
+   divergePoint,         -- Japan diverge with 1 or more lanes
+   downstreamStopLine,   -- Japan style downstream intersection 
+                                   -- (a 2nd intersection) stop line
+   downstreamStartNode,  -- Japan style downstream intersection 
+                                   -- (a 2nd intersection) start node
+     
+   -- Pedestrian Support Attributes
+   closedToTraffic,      -- where a pedestrian may NOT go
+                         -- to be used during construction events
+   safeIsland,           -- a pedestrian safe stopping point
+                         -- also called a traffic island
+                         -- This usage described a point feature on a path, 
+                         -- other entries can describe a path
+   curbPresentAtStepOff, -- the sidewalk to street curb is NOT 
+                         -- angled where it meets the edge of the 
+                         -- roadway (user must step up/down)
+ 
+   -- Lane geometry details  (see standard for defined shapes)
+   hydrantPresent,       -- Or other services access 
+   ...
+   }
+
+NodeAttributeXY ::= ENUMERATED {
+   -- Various values which pertain only to the current node point
+   
+   -- General Items
+   reserved,  
+   stopLine,             -- point where a mid-path stop line exists
+                         -- See also 'do not block' for segments
+
+   -- Path finish details 
+   roundedCapStyleA,      -- Used to control final path rounded end shape
+                          -- with edge of curve at final point in a circle
+   roundedCapStyleB,      -- Used to control final path rounded end shape
+                          -- with edge of curve extending 50% of width past
+                          -- final point in a circle
+   
+   -- Topography Points (items with no concept of a distance along the path)
+   mergePoint,           -- Japan merge with 1 or more lanes
+   divergePoint,         -- Japan diverge with 1 or more lanes
+   downstreamStopLine,   -- Japan style downstream intersection 
+                                   -- (a 2nd intersection) stop line
+   downstreamStartNode,  -- Japan style downstream intersection 
+                                   -- (a 2nd intersection) start node
+     
+   -- Pedestrian Support Attributes
+   closedToTraffic,      -- where a pedestrian may NOT go
+                         -- to be used during construction events
+   safeIsland,           -- a pedestrian safe stopping point
+                         -- also called a traffic island
+                         -- This usage described a point feature on a path, 
+                         -- other entries can describe a path
+   curbPresentAtStepOff, -- the sidewalk to street curb is NOT 
+                         -- angled where it meets the edge of the 
+                         -- roadway (user must step up/down)
+ 
+   -- Lane geometry details  (see standard for defined shapes)
+   hydrantPresent,       -- Or other services access 
+   ...
+   }
+
+NumberOfParticipantsInCluster ::= ENUMERATED { 
+   unavailable  (0),
+   small        (1),   -- 2-5
+   medium       (2),   -- 6-10
+   large        (3),   -- >10
+   ...
+   }
+
+ObjectCount ::= INTEGER (0..1023) -- a count of objects
+
+ObstacleDirection ::= Angle
+
+ObstacleDistance ::= INTEGER (0..32767) -- LSB units of meters
+
+Offset-B09 ::= INTEGER (-256..255)
+   -- a range of +- 2.55 meters
+
+Offset-B10 ::= INTEGER (-512..511)
+   -- a range of +- 5.11 meters
+
+Offset-B11 ::= INTEGER (-1024..1023)
+   -- a range of +- 10.23 meters
+
+Offset-B12 ::= INTEGER (-2048..2047)
+   -- a range of +- 20.47 meters
+
+Offset-B13 ::= INTEGER (-4096..4095)
+   -- a range of +- 40.95 meters
+
+Offset-B14 ::= INTEGER (-8192..8191)
+   -- a range of +- 81.91 meters
+
+Offset-B16 ::= INTEGER (-32768..32767)
+   -- a range of +- 327.68 meters
+
+OffsetLL-B12 ::= INTEGER (-2048..2047)     
+   -- A range of +- 0.0002047 degrees
+   -- In LSB units of 0.1 microdegrees (unless a zoom is employed)
+
+OffsetLL-B14 ::= INTEGER (-8192..8191)     
+   -- A range of +- 0.0008191 degrees
+   -- In LSB units of 0.1 microdegrees (unless a zoom is employed)
+
+OffsetLL-B16 ::= INTEGER (-32768..32767)     
+   -- A range of +- 0.0032767 degrees
+   -- In LSB units of 0.1 microdegrees (unless a zoom is employed)
+
+OffsetLL-B18 ::= INTEGER (-131072..131071)     
+   -- A range of +- 0.0131071 degrees
+   -- The value +131071 shall be used for values >= than +0.0131071 degrees
+   -- The value -131071 shall be used for values <= than -0.0131071 degrees
+   -- The value -131072 shall be used unknown
+   -- In LSB units of 0.1 microdegrees (unless a zoom is employed)
+
+OffsetLL-B22 ::= INTEGER (-2097152..2097151)     
+   -- A range of +- 0.2097151 degrees
+   -- In LSB units of 0.1 microdegrees (unless a zoom is employed) 
+
+OffsetLL-B24 ::= INTEGER (-8388608..8388607)     
+   -- A range of +- 0.8388607 degrees
+   -- In LSB units of 0.1 microdegrees (unless a zoom is employed)
+
+PayloadData ::= OCTET STRING (SIZE(1..2048))
+
+PedestrianBicycleDetect ::= BOOLEAN 
+                 -- true if ANY Pedestrians or Bicyclists are 
+                 -- detected crossing the target lane or lanes
+
+HumanPropelledType ::= ENUMERATED {   
+   unavailable        (0),
+   otherTypes         (1), -- any method not listed below
+   onFoot             (2),
+   skateboard         (3),
+   pushOrKickScooter  (4),
+   wheelchair         (5), -- implies manually powered
+   ...
+}
+
+PersonalAssistive::= BIT STRING {
+   unavailable    (0),
+   otherType      (1),
+   vision         (2),
+   hearing        (3),
+   movement       (4),
+   cognition      (5)
+   } (SIZE (6, ...))
+
+PersonalClusterRadius ::= INTEGER (0..100) -- units of meters
+
+PersonalCrossingInProgress ::= BOOLEAN -- Use:
+   -- True  = Yes, is in maneuver
+   -- False = No
+
+PersonalCrossingRequest ::= BOOLEAN 
+   -- Use:
+   -- True  = On  (request crossing)
+   -- False = Off (no request)
+
+PersonalDeviceUsageState ::= BIT STRING {  
+   unavailable      (0), -- Not specified
+   other            (1), -- Used for states not defined below
+   idle             (2), -- Human is not interacting with device  
+   listeningToAudio (3), -- Any audio source other then calling 
+   typing           (4), -- Including texting, entering addresses 
+                         -- and other manual input activity 
+   calling          (5),   
+   playingGames     (6),   
+   reading          (7),   
+   viewing          (8)  -- Watching dynamic content, including following 
+                         -- navigation prompts, viewing videos or other 
+                         -- visual contents that are not static
+   } (SIZE (9, ...))
+   -- All bits shall be set to zero when unknown state
+
+PersonalDeviceUserType ::= ENUMERATED { 
+   unavailable           (0),
+   aPEDESTRIAN           (1), -- Further details may be provided elsewhere
+   aPEDALCYCLIST         (2), -- Presumed to be human propelled, 
+                              -- unless PropelledInformation indicates motorized
+   aPUBLICSAFETYWORKER   (3),
+   anANIMAL              (4),
+   ...
+   }
+
+PivotingAllowed ::= BOOLEAN 
+
+PositionConfidence ::= ENUMERATED {
+   unavailable (0),  -- B'0000  Not Equipped or unavailable
+   a500m   (1), -- B'0001  500m  or about 5 * 10 ^ -3 decimal degrees
+   a200m   (2), -- B'0010  200m  or about 2 * 10 ^ -3 decimal degrees
+   a100m   (3), -- B'0011  100m  or about 1 * 10 ^ -3 decimal degrees
+   a50m    (4), -- B'0100  50m   or about 5 * 10 ^ -4 decimal degrees 
+   a20m    (5), -- B'0101  20m   or about 2 * 10 ^ -4 decimal degrees 
+   a10m    (6), -- B'0110  10m   or about 1 * 10 ^ -4 decimal degrees 
+   a5m     (7), -- B'0111  5m    or about 5 * 10 ^ -5 decimal degrees 
+   a2m     (8), -- B'1000  2m    or about 2 * 10 ^ -5 decimal degrees 
+   a1m     (9), -- B'1001  1m    or about 1 * 10 ^ -5 decimal degrees 
+   a50cm  (10), -- B'1010  0.50m or about 5 * 10 ^ -6 decimal degrees 
+   a20cm  (11), -- B'1011  0.20m or about 2 * 10 ^ -6 decimal degrees 
+   a10cm  (12), -- B'1100  0.10m or about 1 * 10 ^ -6 decimal degrees 
+   a5cm   (13), -- B'1101  0.05m or about 5 * 10 ^ -7 decimal degrees 
+   a2cm   (14), -- B'1110  0.02m or about 2 * 10 ^ -7 decimal degrees 
+   a1cm   (15)  -- B'1111  0.01m or about 1 * 10 ^ -7 decimal degrees 
+   } 
+   -- Encoded as a 4 bit value
+
+PrioritizationResponseStatus ::= ENUMERATED {
+   unknown           (0),
+                      -- Unknown state
+   requested         (1),
+                      -- This prioritization request was detected 
+                      -- by the traffic controller  
+   processing        (2),
+                      -- Checking request 
+                      -- (request is in queue, other requests are prior)
+   watchOtherTraffic (3),
+                      -- Cannot give full permission, 
+                      -- therefore watch for other traffic
+                      -- Note that other requests may be present
+   granted           (4),
+                      -- Intervention was successful 
+                      -- and now prioritization is active
+   rejected          (5),
+                      -- The prioritization or preemption request was 
+                      -- rejected by the traffic controller
+   maxPresence       (6),
+                      -- The Request has exceeded maxPresence time
+                      -- Used when the controller has determined that
+                      -- the requester should then back off and 
+                      -- request an alternative.  
+   reserviceLocked   (7),
+                      -- Prior conditions have resulted in a reservice 
+                      -- locked event: the controller requires the 
+                      -- passage of time before another similar request 
+                      -- will be accepted
+   ...
+   }
+
+Priority ::= OCTET STRING (SIZE(1)) 
+    -- Follow definition notes on setting these bits
+
+PriorityRequestType ::= ENUMERATED {
+     priorityRequestTypeReserved (0),  
+     priorityRequest             (1),   
+     priorityRequestUpdate       (2), 
+     priorityCancellation        (3),  
+     ...  
+     }
+
+PrivilegedEventFlags ::= BIT STRING {
+   -- These values require a suitable SSP to be sent
+   peUnavailable                (0), -- Not Equipped or unavailable
+   peEmergencyResponse          (1),
+      -- The vehicle is a properly authorized public safety vehicle, 
+      -- is engaged in a service call, and is currently moving 
+      -- or is within the roadway.  Note that lights and sirens 
+      -- may not be evident during any given response call   
+
+   -- Emergency and Non Emergency Lights related
+   peEmergencyLightsActive      (2),
+   peEmergencySoundActive       (3),
+   peNonEmergencyLightsActive   (4),
+   peNonEmergencySoundActive    (5)
+
+   -- this list is likely to grow with further peer review
+   } (SIZE (16))
+
+ProbeSegmentNumber ::= INTEGER (0..32767)  
+   -- value determined by local device 
+   -- as per standard
+
+PublicSafetyAndRoadWorkerActivity ::= BIT STRING {
+   unavailable          (0), -- Not specified
+   workingOnRoad        (1), -- Road workers on foot, in or out of 
+                             -- a closure, performing activities like: 
+                             -- construction, land surveying, 
+                             -- trash removal, or site inspection.
+   settingUpClosures    (2), -- Road workers on foot performing
+                             -- activities like: setting up signs, 
+                             -- placing cones/barrels/pylons, or placing 
+                             -- flares.  Note: People are in the road 
+                             -- redirecting traffic, but the closure is 
+                             -- not complete, so utmost care is required 
+                             -- to determine the allowed path to take to 
+                             -- avoid entering the work zone and/or 
+                             -- harming the workers.
+   respondingToEvents   (3), -- Public safety or other road workers on
+                             -- foot performing activities like: treating 
+                             -- injured people, putting out fires, 
+                             -- cleaning chemical spills, aiding disabled 
+                             -- vehicles, criminal investigations, 
+                             -- or animal control.  Note: These events tend 
+                             -- to be more dynamic than workingOnRoad
+   directingTraffic     (4), -- Public safety or other road workers on
+                             -- foot directing traffic in situations like: 
+                             -- a traffic signal out of operation, 
+                             -- a construction or crash site with a short 
+                             -- term lane closure, a single lane flagging 
+                             -- operation, or ingress/egress to a special event.
+   otherActivities      (5)  -- Designated by regional authorities  
+   } (SIZE (6, ...))
+
+PublicSafetyDirectingTrafficSubType ::= BIT STRING {
+   unavailable                        (0),
+      -- Default.  
+      -- to be used if unknown or if the worker type is not otherwise identified
+   policeAndTrafficOfficers           (1), 
+      -- Law enforcement officers, including traffic control officers,
+      -- and adult school crossing guards.
+   trafficControlPersons              (2), 
+     -- Road workers with special equipment for directing traffic.
+   railroadCrossingGuards             (3), 
+     -- Railroad crossing guards who notify motorists of approaching trains 
+     -- at locations like private roads or driveways crossing train tracks 
+     -- and where automated equipment is disabled or not present. 
+   civilDefenseNationalGuardMilitaryPolice (4),
+        -- while performing their regular duties or during National
+     -- or local emergencies
+   emergencyOrganizationPersonnel     (5),
+      -- Personnel belonging to emergency response organizations such as
+      -- fire departments, hospitals, river rescue, or associated with
+      -- emergency vehicles including ambulances as designated by the 
+      -- regional authority (relating to designation of emergency vehicles)
+      -- while performing their duties.
+   highwayServiceVehiclePersonnel     (6)
+      -- Associated with tow trucks and road service vehicles.
+   } (SIZE (7, ...))
+
+PublicSafetyEventResponderWorkerType ::= ENUMERATED { 
+   unavailable               (0),
+   towOperater               (1),
+   fireAndEMSWorker          (2),
+   aDOTWorker                (3),
+   lawEnforcement            (4),
+   hazmatResponder           (5), -- also any toxicSubstanceCleanupCrew
+   animalControlWorker       (6),
+   otherPersonnel            (7),
+   ...
+   }
+
+RadiusOfCurvature ::= INTEGER (-32767..32767)
+   -- LSB units of 10cm
+   -- A straight path to use value of 32767
+
+Radius-B12 ::= INTEGER (0..4095)
+   -- with the LSB unit value determined elsewhere
+   -- the value 4095 shall be used for unknown
+
+RainSensor ::= ENUMERATED {
+     none               (0), 
+     lightMist          (1), 
+     heavyMist          (2), 
+     lightRainOrDrizzle (3),
+     rain               (4),
+     moderateRain       (5),
+     heavyRain          (6),
+     heavyDownpour      (7) 
+     }
+
+RegionId ::= INTEGER (0..255)
+   noRegion     RegionId ::= 0  -- Use default supplied stubs
+   addGrpA      RegionId ::= 1  -- USA
+   addGrpB      RegionId ::= 2  -- Japan
+   addGrpC      RegionId ::= 3  -- EU
+   -- NOTE: new registered regional IDs will be added here
+   -- The values 128 and above are for local region use
+
+RequestedItem ::= ENUMERATED {
+   reserved,
+   itemA,
+        -- consisting of 2 elements: 
+        -- lights          ExteriorLights 
+        -- lightBar        LightbarInUse 
+   
+   itemB,
+        -- consisting of: 
+        -- wipers  a SEQUENCE
+   
+   itemC,
+        -- consisting of: 
+        -- brakeStatus  BrakeSystemStatus 
+
+   itemD,
+        -- consisting of 2 elements: 
+        -- brakePressure   BrakeAppliedPressure   
+        -- roadFriction    CoefficientOfFriction   
+      
+   itemE,
+        -- consisting of 4 elements: 
+        -- sunData         SunSensor                
+        -- rainData        RainSensor                   
+        -- airTemp         AmbientAirTemperature     
+        -- airPres         AmbientAirPressure     
+   
+   itemF,
+        -- consisting of: 
+        -- steering  a SEQUENCE 
+    
+   itemG,
+        -- consisting of: 
+        -- accelSets a SEQUENCE 
+
+   itemI,
+        -- consisting of: 
+        -- fullPos         FullPositionVector       
+   
+   itemJ,
+        -- consisting of: 
+        -- position2D      Position2D  
+
+   itemK,
+        -- consisting of: 
+        -- position3D      Position3D 
+ 
+   itemL,
+        -- consisting of 2 elements: 
+        -- speedHeadC      SpeedandHeadingConfidence     
+   
+   itemM,
+        -- consisting of: 
+        -- vehicleData a SEQUENCE   
+   
+   itemN,
+        -- consisting of: 
+        -- vehicleIdent   VehicleIdent 
+   
+   itemO,
+        -- consisting of: 
+        -- weatherReport a SEQUENCE   
+   
+   itemP,
+        -- consisting of: 
+        -- breadcrumbs    PathHistory 
+   
+   itemQ,
+        -- consisting of: 
+        -- GNSSStatus      GNSSstatus      
+      
+   ...    
+   }
+
+RequestID ::= INTEGER (0..255)
+
+RequestImportanceLevel ::= ENUMERATED {
+    requestImportanceLevelUnKnown  (0),
+    requestImportanceLevel1        (1), -- The least important request
+    requestImportanceLevel2        (2), -- The values here shall be assigned
+    requestImportanceLevel3        (3), -- Meanings based on regional needs
+    requestImportanceLevel4        (4), -- for each of the basic roles which
+    requestImportanceLevel5        (5), -- are defined elsewhere
+    requestImportanceLevel6        (6),
+    requestImportanceLevel7        (7),
+    requestImportanceLevel8        (8),
+    requestImportanceLevel9        (9),
+    requestImportanceLevel10      (10),
+    requestImportanceLevel11      (11),
+    requestImportanceLevel12      (12),
+    requestImportanceLevel13      (13),
+    requestImportanceLevel14      (14), -- The most important request
+    requestImportanceReserved     (15)  -- Reserved for future use
+    }
+
+RequestSubRole ::= ENUMERATED {
+    requestSubRoleUnKnown    (0),
+    requestSubRole1          (1), -- The first type of sub role
+    requestSubRole2          (2), -- The values here shall be assigned
+    requestSubRole3          (3), -- Meanings based on regional needs
+    requestSubRole4          (4), -- to refine and expand the basic
+    requestSubRole5          (5), -- roles which are defined elsewhere
+    requestSubRole6          (6),
+    requestSubRole7          (7),
+    requestSubRole8          (8),
+    requestSubRole9          (9),
+    requestSubRole10        (10),
+    requestSubRole11        (11),
+    requestSubRole12        (12),
+    requestSubRole13        (13),
+    requestSubRole14        (14), -- The last type of sub role
+    requestSubRoleReserved  (15)  -- Reserved for future use
+    }
+
+ResponseType ::= ENUMERATED {
+   notInUseOrNotEquipped      (0),            
+   emergency                  (1),  -- active service call at emergency level           
+   nonEmergency               (2),  -- also used when returning from service call          
+   pursuit                    (3),  -- sender driving may be erratic 
+   stationary                 (4),  -- sender is not moving, stopped along roadside
+   slowMoving                 (5),  -- such a mowers, litter trucks, etc.
+   stopAndGoMovement          (6),  -- such as school bus or garbage truck   
+   ...
+   } 
+
+RestrictionAppliesTo ::= ENUMERATED {
+    none,              -- applies to nothing
+    equippedTransit,   -- buses etc.
+    equippedTaxis,
+    equippedOther,     -- other vehicle types with
+                       -- necessary signal phase state
+                       -- reception equipment
+    emissionCompliant, -- regional variants with more
+                       -- definitive items also exist
+    equippedBicycle,
+    weightCompliant,
+    heightCompliant,
+    -- Items dealing with traveler needs serviced by the infrastructure
+    -- These end users (which are not vehicles) are presumed to be suitably equipped
+    pedestrians,
+    slowMovingPersons,
+    wheelchairUsers,
+    visualDisabilities,
+    audioDisabilities,  -- hearing
+    otherUnknownDisabilities,
+    ...
+    }
+
+RestrictionClassID ::= INTEGER (0..255)
+   -- An index value to identify data about classes of users
+   -- the value used varies with each intersection's
+   -- needs and is defined in the map to the assigned 
+   -- classes of supported users.
+
+RoadRegulatorID ::= INTEGER (0..65535)
+   -- The value zero shall be used for testing only
+
+RoadSegmentID ::= INTEGER (0..65535)
+   -- The values zero to 255 shall be used for testing only
+   -- Note that the value assigned to an RoadSegment will be
+   -- unique within a given regional ID only during its use
+
+RoadwayCrownAngle ::= INTEGER (-128..127) 
+    -- In LSB units of 0.3 degrees of angle
+    -- over a range of -38.1 to + 38.1 degrees
+    -- The value -128 shall be used for unknown
+    -- The value zero shall be used for angles 
+    -- which are between -0.15 and +0.15
+
+RTCM-Revision ::= ENUMERATED {
+     unknown       (0), 
+     rtcmRev2      (1), -- Std 10402.x et al
+     rtcmRev3      (2), -- Std 10403.x et al
+     reserved      (3),
+     ...  
+     }
+
+RTCMmessage ::= OCTET STRING (SIZE(1..1023))
+
+Scale-B12 ::= INTEGER (-2048..2047)  -- in steps of 0.05 percent
+
+SecondOfTime ::= INTEGER (0..61)  -- units of seconds
+    -- The value 60 shall be used for leap seconds
+    -- or to indicate a full minute.
+    -- The value 61 indicates that the value is unavailable
+
+SegmentAttributeLL ::= ENUMERATED { 
+   -- Various values which can be Enabled and Disabled for a lane segment
+   
+   -- General Items
+   reserved                  ,  
+   doNotBlock                ,  -- segment where a vehicle 
+                                -- may not come to a stop
+   whiteLine                 ,  -- segment where lane crossing not allowed
+                                -- such as the final few meters of a lane
+   
+   -- Porous Lane states, merging, turn outs, parking etc.
+   
+   mergingLaneLeft           ,  -- indicates porous lanes
+   mergingLaneRight          ,
+   
+   curbOnLeft                ,  -- indicates presence of curbs
+   curbOnRight               ,
+   
+   loadingzoneOnLeft         ,  -- loading or drop off zones
+   loadingzoneOnRight        ,
+   
+   turnOutPointOnLeft        ,  -- opening to adjacent street/alley/road
+   turnOutPointOnRight       ,
+   
+   adjacentParkingOnLeft     , -- side of road parking
+   adjacentParkingOnRight    ,
+   
+   -- Bike Lane Needs
+   adjacentBikeLaneOnLeft    , -- presence of marked bike lanes
+   adjacentBikeLaneOnRight   ,
+   sharedBikeLane            , -- right of way is shared with bikes
+                               -- who may occupy entire lane width
+   bikeBoxInFront            ,
+   
+   -- Transit Needs
+   transitStopOnLeft         , -- any form of bus/transit loading
+                               -- with pull in-out access to lane on left
+   transitStopOnRight        , -- any form of bus/transit loading
+                               -- with pull in-out access to lane on right
+   transitStopInLane         , -- any form of bus/transit loading
+                               -- in mid path of the lane
+   sharedWithTrackedVehicle  , -- lane is shared with train or trolley 
+                               -- not used for crossing tracks
+  
+     
+   -- Pedestrian Support Attributes
+   safeIsland                , -- begin/end a safety island in path
+   lowCurbsPresent           , -- for ADA support
+   rumbleStripPresent        , -- for ADA support
+   audibleSignalingPresent   , -- for ADA support
+   adaptiveTimingPresent     , -- for ADA support
+   rfSignalRequestPresent    , -- Supports RF push to walk technologies
+   partialCurbIntrusion      , -- path is blocked by a median or curb 
+                               -- but at least 1 meter remains open for use
+                               -- and at-grade passage
+   
+   -- Lane geometry details  (see standard for defined shapes)
+   taperToLeft               , -- Used to control final path shape
+   taperToRight              , -- Used to control final path shape
+   taperToCenterLine         , -- Used to control final path shape
+
+   -- Parking Lane and Curb Attributes
+   parallelParking           , -- 
+   headInParking             , -- Parking at an angle with the street
+   freeParking               , -- no restriction on use of parking
+   timeRestrictionsOnParking , -- Parking is not permitted at all times
+                               -- typically used when the 'parking' lane 
+                               -- becomes a driving lane at times
+   costToPark                , -- Used where parking has a cost
+   midBlockCurbPresent       , -- a protruding curb near lane edge
+   unEvenPavementPresent     , -- a disjoint height at lane edge
+   ...
+   }
+
+SegmentAttributeXY ::= ENUMERATED {
+   -- Various values which can be Enabled and Disabled for a lane segment
+   
+   -- General Items
+   reserved                  ,  
+   doNotBlock                ,  -- segment where a vehicle 
+                                -- may not come to a stop
+   whiteLine                 ,  -- segment where lane crossing not allowed
+                                -- such as the final few meters of a lane
+   
+   -- Porous Lane states, merging, turn outs, parking etc.
+   
+   mergingLaneLeft           ,  -- indicates porous lanes
+   mergingLaneRight          ,
+   
+   curbOnLeft                ,  -- indicates presence of curbs
+   curbOnRight               ,
+   
+   loadingzoneOnLeft         ,  -- loading or drop off zones
+   loadingzoneOnRight        ,
+   
+   turnOutPointOnLeft        ,  -- opening to adjacent street/alley/road
+   turnOutPointOnRight       ,
+   
+   adjacentParkingOnLeft     , -- side of road parking
+   adjacentParkingOnRight    ,
+   
+   -- Bike Lane Needs
+   adjacentBikeLaneOnLeft    , -- presence of marked bike lanes
+   adjacentBikeLaneOnRight   ,
+   sharedBikeLane            , -- right of way is shared with bikes
+                               -- who may occupy entire lane width
+   bikeBoxInFront            ,
+   
+   -- Transit Needs
+   transitStopOnLeft         , -- any form of bus/transit loading
+                               -- with pull in-out access to lane on left
+   transitStopOnRight        , -- any form of bus/transit loading
+                               -- with pull in-out access to lane on right
+   transitStopInLane         , -- any form of bus/transit loading
+                               -- in mid path of the lane
+   sharedWithTrackedVehicle  , -- lane is shared with train or trolley 
+                               -- not used for crossing tracks
+  
+     
+   -- Pedestrian Support Attributes
+   safeIsland                , -- begin/end a safety island in path
+   lowCurbsPresent           , -- for ADA support
+   rumbleStripPresent        , -- for ADA support
+   audibleSignalingPresent   , -- for ADA support
+   adaptiveTimingPresent     , -- for ADA support
+   rfSignalRequestPresent    , -- Supports RF push to walk technologies
+   partialCurbIntrusion      , -- path is blocked by a median or curb 
+                               -- but at least 1 meter remains open for use
+                               -- and at-grade passage
+   
+   -- Lane geometry details  (see standard for defined shapes)
+   taperToLeft               , -- Used to control final path shape
+   taperToRight              , -- Used to control final path shape
+   taperToCenterLine         , -- Used to control final path shape
+
+   -- Parking Lane and Curb Attributes
+   parallelParking           , -- 
+   headInParking             , -- Parking at an angle with the street
+   freeParking               , -- no restriction on use of parking
+   timeRestrictionsOnParking , -- Parking is not permitted at all times
+                               -- typically used when the 'parking' lane 
+                               -- becomes a driving lane at times
+   costToPark                , -- Used where parking has a cost
+   midBlockCurbPresent       , -- a protruding curb near lane edge
+   unEvenPavementPresent     , -- a disjoint height at lane edge
+   ...
+   }
+
+SemiMajorAxisAccuracy ::= INTEGER (0..255)
+   -- semi-major axis accuracy at one standard dev 
+   -- range 0-12.7 meter, LSB = .05m
+   -- 254 = any value equal or greater than 12.70 meter
+   -- 255 = unavailable semi-major axis value
+
+SemiMajorAxisOrientation ::= INTEGER (0..65535)
+   -- orientation of semi-major axis 
+   -- relative to true north (0~359.9945078786 degrees)
+   -- LSB units of 360/65535 deg  = 0.0054932479
+   -- a value of 0 shall be 0 degrees
+   -- a value of 1 shall be 0.0054932479 degrees 
+   -- a value of 65534 shall be 359.9945078786 deg
+   -- a value of 65535 shall be used for orientation unavailable
+
+SemiMinorAxisAccuracy ::= INTEGER (0..255)
+   -- semi-minor axis accuracy at one standard dev 
+   -- range 0-12.7 meter, LSB = .05m
+   -- 254 = any value equal or greater than 12.70 meter
+   -- 255 = unavailable semi-minor axis value
+
+SignalGroupID ::= INTEGER (0..255) 
+    -- The value 0 shall be used when the ID is
+    -- not available or not known
+    -- the value 255 is reserved to indicate a 
+    -- permanent green movement state
+    -- therefore a simple 8 phase signal controller 
+    -- device might use 1..9 as its groupIDs
+
+SignalReqScheme ::= OCTET STRING (SIZE(1)) 
+    -- Encoded as follows: 
+   -- upper nibble:  Preempt #:  
+    -- Bit 7 (MSB) 1 =  Preempt and 0 =  Priority 
+    -- Remaining 3 bits: 
+    -- Range of 0..7. The values of 1..6 represent 
+    -- the respective controller preempt or Priority 
+    -- to be activated. The value of 7 represents a 
+    -- request for a cabinet flash prempt, 
+    -- while the value of 0 is reserved.  
+   
+   -- lower nibble:  Strategy #:  
+    -- Range is 0..15 and is used to specify a desired 
+    -- strategy (if available).  
+    -- Currently no strategies are defined and this 
+    -- should be zero.
+
+SignPrority ::= INTEGER (0..7)
+   -- 0 as least, 7 as most
+
+SirenInUse ::= ENUMERATED {
+     unavailable   (0), -- Not Equipped or unavailable
+     notInUse      (1),  
+     inUse         (2),  
+     reserved      (3)  -- for future use
+     }
+
+SpeedAdvice ::= INTEGER (0..500) 
+    -- LSB units are 0.1 m/s^2
+    -- the value 499 shall be used for values at or greater than 49.9 m/s
+    -- the value 500 shall be used to indicate that speed is unavailable
+
+SpeedConfidence ::= ENUMERATED {
+   unavailable (0), -- Not Equipped or unavailable
+   prec100ms   (1), -- 100  meters / sec
+   prec10ms    (2), -- 10   meters / sec
+   prec5ms     (3), -- 5    meters / sec
+   prec1ms     (4), -- 1    meters / sec
+   prec0-1ms   (5), -- 0.1  meters / sec
+   prec0-05ms  (6), -- 0.05 meters / sec
+   prec0-01ms  (7)  -- 0.01 meters / sec
+   }
+
+SpeedLimitType ::= ENUMERATED {
+    unknown,                    -- Speed limit type not available
+    maxSpeedInSchoolZone,       -- Only sent when the limit is active
+    maxSpeedInSchoolZoneWhenChildrenArePresent, -- Sent at any time
+    maxSpeedInConstructionZone, -- Used for work zones, incident zones, etc.
+                                -- where a reduced speed is present
+    vehicleMinSpeed,
+    vehicleMaxSpeed,            -- Regulatory speed limit for general traffic
+    vehicleNightMaxSpeed,
+
+    truckMinSpeed,
+    truckMaxSpeed,
+    truckNightMaxSpeed,
+
+    vehiclesWithTrailersMinSpeed,
+    vehiclesWithTrailersMaxSpeed,
+    vehiclesWithTrailersNightMaxSpeed,
+    ...
+    }
+
+SpeedProfileMeasurement ::= GrossSpeed 
+
+Speed ::= INTEGER (0..8191) -- Units of 0.02 m/s
+          -- The value 8191 indicates that 
+          -- speed is unavailable
+
+SSPindex ::= INTEGER (0..31)
+
+StabilityControlStatus ::= ENUMERATED {
+   unavailable (0), -- B'00  Not Equipped with SC
+                    --       or SC status is unavailable
+   off         (1), -- B'01  Off
+   on          (2), -- B'10  On or active (but not engaged)
+   engaged     (3)  -- B'11  stability control is Engaged 
+   }
+
+StationID ::= INTEGER (0..4294967295)
+
+SteeringWheelAngleConfidence ::= ENUMERATED {
+   unavailable (0), -- B'00  Not Equipped with Wheel angle
+                    -- or Wheel angle status is unavailable
+   prec2deg    (1), -- B'01  2 degrees
+   prec1deg    (2), -- B'10  1 degree
+   prec0-02deg (3)  -- B'11  0.02 degrees
+   }
+
+SteeringWheelAngleRateOfChange ::= INTEGER (-127..127) 
+   -- LSB is 3 degrees per second
+
+SteeringWheelAngle ::= INTEGER (-126..127) 
+    -- LSB units of 1.5 degrees, a range of -189 to +189 degrees
+    -- +001 = +1.5 deg
+    -- -126 = -189 deg and beyond  
+    -- +126 = +189 deg and beyond
+    -- +127 to be used for unavailable
+
+SunSensor ::= INTEGER (0..1000) 
+   -- units of watts / m2
+
+TemporaryID ::= OCTET STRING (SIZE(4))
+
+TermDistance ::= INTEGER (1..30000)   -- units in meters
+
+TermTime ::= INTEGER (1..1800) -- units of sec
+
+ThrottleConfidence ::= ENUMERATED {
+   unavailable     (0), -- B'00  Not Equipped or unavailable
+   prec10percent   (1), -- B'01  10  percent Confidence level
+   prec1percent    (2), -- B'10  1   percent Confidence level
+   prec0-5percent  (3)  -- B'11  0.5 percent Confidence level
+   }
+
+ThrottlePosition ::= INTEGER (0..200) -- LSB units are 0.5 percent
+
+TimeConfidence ::= ENUMERATED {
+   unavailable              (0), -- Not Equipped or unavailable
+   time-100-000             (1), -- Better than  100 Seconds
+   time-050-000             (2), -- Better than  50 Seconds
+   time-020-000             (3), -- Better than  20 Seconds
+   time-010-000             (4), -- Better than  10 Seconds
+   time-002-000             (5), -- Better than  2 Seconds
+   time-001-000             (6), -- Better than  1 Second
+   time-000-500             (7), -- Better than  0.5 Seconds
+   time-000-200             (8), -- Better than  0.2 Seconds
+   time-000-100             (9), -- Better than  0.1 Seconds
+   time-000-050            (10), -- Better than  0.05 Seconds
+   time-000-020            (11), -- Better than  0.02 Seconds
+   time-000-010            (12), -- Better than  0.01 Seconds
+   time-000-005            (13), -- Better than  0.005 Seconds
+   time-000-002            (14), -- Better than  0.002 Seconds
+   time-000-001            (15), -- Better than  0.001 Seconds
+                                 -- Better than  one millisecond
+   time-000-000-5          (16), -- Better than  0.000,5 Seconds
+   time-000-000-2          (17), -- Better than  0.000,2 Seconds
+   time-000-000-1          (18), -- Better than  0.000,1 Seconds
+   time-000-000-05         (19), -- Better than  0.000,05 Seconds
+   time-000-000-02         (20), -- Better than  0.000,02 Seconds
+   time-000-000-01         (21), -- Better than  0.000,01 Seconds
+   time-000-000-005        (22), -- Better than  0.000,005 Seconds
+   time-000-000-002        (23), -- Better than  0.000,002 Seconds
+   time-000-000-001        (24), -- Better than  0.000,001 Seconds 
+                                 -- Better than  one micro second
+   time-000-000-000-5      (25), -- Better than  0.000,000,5 Seconds
+   time-000-000-000-2      (26), -- Better than  0.000,000,2 Seconds
+   time-000-000-000-1      (27), -- Better than  0.000,000,1 Seconds
+   time-000-000-000-05     (28), -- Better than  0.000,000,05 Seconds
+   time-000-000-000-02     (29), -- Better than  0.000,000,02 Seconds
+   time-000-000-000-01     (30), -- Better than  0.000,000,01 Seconds
+   time-000-000-000-005    (31), -- Better than  0.000,000,005 Seconds
+   time-000-000-000-002    (32), -- Better than  0.000,000,002 Seconds
+   time-000-000-000-001    (33), -- Better than  0.000,000,001 Seconds
+                                 -- Better than  one nano second
+   time-000-000-000-000-5  (34), -- Better than  0.000,000,000,5 Seconds
+   time-000-000-000-000-2  (35), -- Better than  0.000,000,000,2 Seconds
+   time-000-000-000-000-1  (36), -- Better than  0.000,000,000,1 Seconds
+   time-000-000-000-000-05 (37), -- Better than  0.000,000,000,05 Seconds
+   time-000-000-000-000-02 (38), -- Better than  0.000,000,000,02 Seconds
+   time-000-000-000-000-01 (39)  -- Better than  0.000,000,000,01 Seconds 
+   }
+
+TimeIntervalConfidence ::= INTEGER (0..15)   
+   -- Value   Probability
+   --   0         21%
+   --   1         36%
+   --   2         47%
+   --   3         56%
+   --   4         62%
+   --   5         68%
+   --   6         73%
+   --   7         77%
+   --   8         81%
+   --   9         85%
+   --   10        88%
+   --   11        91%
+   --   12        94%
+   --   13        96%
+   --   14        98%
+   --   15        100%
+
+TimeMark ::= INTEGER (0..36001)
+   -- Tenths of a second in the current or next hour
+   -- In units of 1/10th second from UTC time
+   -- A range of 0~36000 covers one hour
+   -- The values 35991..35999 are used when a leap second occurs
+   -- The value 36000 is used to indicate time >3600 seconds
+   -- 36001 is to be used when value undefined or unknown
+   -- Note that this is NOT expressed in GPS time
+   -- or in local time
+
+TimeOffset ::= INTEGER (1..65535)
+   -- LSB units of of 10 mSec, 
+   -- with a range of 0.01 seconds to 10 minutes and 55.34 seconds
+   -- a value of 65534 to be used for 655.34 seconds or greater
+   -- a value of 65535 to be unavailable
+
+TractionControlStatus ::= ENUMERATED {
+   unavailable (0), -- B'00  Not Equipped with traction control 
+                    --       or traction control status is unavailable
+   off         (1), -- B'01  traction control is Off
+   on          (2), -- B'10  traction control is On (but not Engaged)
+   engaged     (3)  -- B'11  traction control is Engaged
+   }
+
+TrailerMass ::= INTEGER (0..255) 
+   -- object mass with LSB steps of 500 kg (~1100 lbs)
+   -- the value zero shall be uaed for an unknown mass value
+   -- the value 255 shall be used any mass larger than 127,500kg
+   -- a useful range of 0~127.5 metric tons. 
+
+TransitStatus ::= BIT STRING {
+    none        (0), -- nothing is active
+    anADAuse    (1), -- an ADA access is in progress (wheelchairs, kneeling, etc.)
+    aBikeLoad   (2), -- loading of a bicyle is in progress
+    doorOpen    (3), -- a vehicle door is open for passenger access
+    occM        (4),
+    occL        (5)
+    -- bits four and five are used to relate the 
+    -- the relative occupancy of the vehicle, with
+    -- 00  as least full and 11 indicating a 
+    -- close-to or full conditon
+    } (SIZE(6))
+
+TransitVehicleOccupancy ::= ENUMERATED {
+    occupancyUnknown    (0),  
+    occupancyEmpty      (1),  
+    occupancyVeryLow    (2),  
+    occupancyLow        (3),  
+    occupancyMed        (4),  
+    occupancyHigh       (5),  
+    occupancyNearlyFull (6),  
+    occupancyFull       (7)
+    }
+
+TransitVehicleStatus ::= BIT STRING {
+    loading     (0), -- parking and unable to move at this time
+    anADAuse    (1), -- an ADA access is in progress (wheelchairs, kneeling, etc.)
+    aBikeLoad   (2), -- loading of a bicycle is in progress
+    doorOpen    (3), -- a vehicle door is open for passenger access
+    charging    (4), -- a vehicle is connected to charging point
+    atStopLine  (5)  -- a vehicle is at the stop line for the lane it is in
+    } (SIZE(8))
+
+TransmissionState ::= ENUMERATED {
+   neutral      (0), -- Neutral
+   park         (1), -- Park 
+   forwardGears (2), -- Forward gears
+   reverseGears (3), -- Reverse gears 
+   reserved1    (4),      
+   reserved2    (5),      
+   reserved3    (6),      
+   unavailable  (7)  -- not-equipped or unavailable value,
+   -- Any related speed is relative to the vehicle reference frame used
+   }
+
+TravelerInfoType ::= ENUMERATED {
+     unknown            (0), 
+     advisory           (1),
+     roadSignage        (2), 
+     commercialSignage  (3),
+     ...  
+     } 
+
+UniqueMSGID ::= OCTET STRING (SIZE(9))
+
+URL-Base ::= IA5String (SIZE(1..45))
+
+URL-Link ::= IA5String (SIZE(1..255))
+
+URL-Short ::= IA5String (SIZE(1..15))
+
+UserSizeAndBehaviour ::= BIT STRING { 
+   unavailable                     (0),
+   smallStature                    (1), -- less than 150 cm high
+   largeStature                    (2),
+   erraticMoving                   (3), 
+   slowMoving                      (4)  -- those who move a bit slowly
+   } (SIZE (5, ...))
+
+VehicleEventFlags ::= BIT STRING {
+   eventHazardLights               (0),
+   eventStopLineViolation          (1), -- Intersection Violation   
+   eventABSactivated               (2),
+   eventTractionControlLoss        (3),
+   eventStabilityControlactivated  (4),
+   eventHazardousMaterials         (5),
+   eventReserved1                  (6),   
+   eventHardBraking                (7),
+   eventLightsChanged              (8),
+   eventWipersChanged              (9),
+   eventFlatTire                   (10),
+   eventDisabledVehicle            (11), -- The DisabledVehicle DF may also be sent
+   eventAirBagDeployment           (12)
+   } (SIZE (13, ...))
+
+VehicleHeight ::= INTEGER (0..127) 
+    -- the height of the vehicle
+    -- LSB units of 5 cm, range to 6.35 meters
+
+VehicleLength ::= INTEGER (0.. 4095) -- LSB units of 1 cm with a range of >40 meters
+
+VehicleMass ::= INTEGER (0..255)
+    -- Values 000 to 080 in steps of 50kg
+    -- Values 081 to 200 in steps of 500kg
+    -- Values 201 to 253 in steps of 2000kg
+    -- The Value 254 shall be used for weights above 170000 kg
+    -- The Value 255 shall be used when the value is unknown or unavailable
+    -- Encoded such that the values:
+    --  81 represents   4500 kg
+    -- 181 represents  54500 kg
+    -- 253 represents 170000 kg
+
+VehicleStatusDeviceTypeTag ::= ENUMERATED {
+   unknown            (0),
+   lights             (1),  -- Exterior Lights
+   wipers             (2),  -- Wipers
+   brakes             (3),  -- Brake Applied                
+   stab               (4),  -- Stability Control        
+   trac               (5),  -- Traction Control        
+   abs                (6),  -- Anti-Lock Brakes        
+   sunS               (7),  -- Sun Sensor        
+   rainS              (8),  -- Rain Sensor        
+   airTemp            (9),  -- Air Temperature    
+   steering           (10),
+   vertAccelThres     (11), -- Wheel that Exceeded the
+   vertAccel          (12), -- Vertical g Force Value  
+   hozAccelLong       (13), -- Longitudinal Acceleration        
+   hozAccelLat        (14), -- Lateral Acceleration        
+   hozAccelCon        (15), -- Acceleration Confidence 
+   accel4way          (16),
+   confidenceSet      (17),
+   obDist             (18), -- Obstacle Distance        
+   obDirect           (19), -- Obstacle Direction        
+   yaw                (20), -- Yaw Rate        
+   yawRateCon         (21), -- Yaw Rate Confidence
+   dateTime           (22), -- complete time
+   fullPos            (23), -- complete set of time and
+                            -- position, speed, heading
+   position2D         (24), -- lat, long
+   position3D         (25), -- lat, long, elevation
+   vehicle            (26), -- height, mass, type
+   speedHeadC         (27), 
+   speedC             (28),
+   
+   ...  
+   }
+
+VehicleType ::= ENUMERATED {
+   none                 (0),  -- Not Equipped, Not known or unavailable
+   unknown              (1),  -- Does not fit any other category    
+   special              (2),  -- Special use    
+   moto                 (3),  -- Motorcycle    
+   car                  (4),  -- Passenger car    
+   carOther             (5),  -- Four tire single units    
+   bus                  (6),  -- Buses    
+   axleCnt2             (7),  -- Two axle, six tire single units    
+   axleCnt3             (8),  -- Three axle, single units    
+   axleCnt4             (9),  -- Four or more axle, single unit    
+   axleCnt4Trailer      (10), -- Four or less axle, single trailer    
+   axleCnt5Trailer      (11), -- Five or less axle, single trailer    
+   axleCnt6Trailer      (12), -- Six or more axle, single trailer    
+   axleCnt5MultiTrailer (13), -- Five or less axle, multi-trailer    
+   axleCnt6MultiTrailer (14), -- Six axle, multi-trailer    
+   axleCnt7MultiTrailer (15),  -- Seven or more axle, multi-trailer    
+   ...  
+   } 
+
+VehicleWidth ::= INTEGER (0..1023) -- LSB units are 1 cm with a range of >10 meters
+
+Velocity ::= INTEGER (0..8191) -- Units of 0.02 m/s
+    -- The value 8191 indicates that 
+    -- velocity is unavailable
+
+VerticalAccelerationThreshold ::= BIT STRING {
+   notEquipped (0), -- Not equipped or off
+   leftFront   (1), -- Left Front Event
+   leftRear    (2), -- Left Rear Event
+   rightFront  (3), -- Right Front Event
+   rightRear   (4)  -- Right Rear Event
+   } (SIZE(5))
+
+VerticalAcceleration ::= INTEGER (-127..127) 
+   -- LSB units of 0.02 G steps over -2.52 to +2.54 G
+   -- The value +127 shall be used for ranges >= 2.54 G
+   -- The value -126 shall be used for ranges <= 2.52 G
+   -- The value -127 shall be used for unavailable
+
+VertOffset-B07 ::= INTEGER (-64..63)  
+   -- LSB units of of 10 cm
+   -- with a range of +- 6.3 meters vertical 
+   -- value  63 to be used for  63 or greater
+   -- value -63 to be used for -63 or greater
+   -- value -64 to be unavailable
+
+VertOffset-B08 ::= INTEGER (-128..127)  
+   -- LSB units of of 10 cm
+   -- with a range of +- 12.7 meters vertical
+   -- value  127 to be used for  127 or greater
+   -- value -127 to be used for -127 or greater
+   -- value -128 to be unavailable
+
+VertOffset-B09 ::= INTEGER (-256..255)  
+   -- LSB units of of 10 cm
+   -- with a range of +- 25.5 meters vertical
+   -- value  255 to be used for  255 or greater
+   -- value -255 to be used for -255 or greater
+   -- value -256 to be unavailable
+
+VertOffset-B10 ::= INTEGER (-512..511)  
+   -- LSB units of of 10 cm
+   -- with a range of +- 51.1 meters vertical
+   -- value  511 to be used for  511 or greater
+   -- value -511 to be used for -511 or greater
+   -- value -512 to be unavailable
+
+VertOffset-B11 ::= INTEGER (-1024..1023)  
+   -- LSB units of of 10 cm
+   -- with a range of +- 102.3 meters vertical
+   -- value  1023 to be used for  1023 or greater
+   -- value -1023 to be used for -1023 or greater
+   -- value -1024 to be unavailable
+
+VertOffset-B12 ::= INTEGER (-2048..2047)  
+   -- LSB units of of 10 cm
+   -- with a range of +- 204.7 meters vertical
+   -- value  2047 to be used for  2047 or greater
+   -- value -2047 to be used for -2047 or greater
+   -- value -2048 to be unavailable
+
+VINstring ::= OCTET STRING (SIZE(1..17)) 
+   -- A legal VIN or a shorter value 
+   -- to provide an ident of the vehicle
+   -- If a VIN is sent, then IA5 encoding 
+   -- shall be used
+
+WaitOnStopline ::= BOOLEAN -- 
+         -- True or False
+         -- If "true", the vehicles on this specific connecting 
+         -- maneuver have to stop on the stop-line
+         -- and not to enter the collision area
+
+WiperRate ::= INTEGER (0..127) -- units of sweeps per minute
+
+WiperStatus ::= ENUMERATED {
+     unavailable         (0), -- Not Equipped with wiper status
+                              -- or wiper status is unavailable
+     off                 (1),  
+     intermittent        (2), 
+     low                 (3),
+     high                (4),
+     washerInUse         (5), -- washing solution being used
+     automaticPresent    (6), -- Auto wiper equipped
+     ...  
+     }
+
+YawRateConfidence ::= ENUMERATED {
+   unavailable    (0), -- B'000  Not Equipped with yaw rate status
+                       -- or yaw rate status is unavailable
+   degSec-100-00  (1), -- B'001  100  deg/sec
+   degSec-010-00  (2), -- B'010  10   deg/sec
+   degSec-005-00  (3), -- B'011  5    deg/sec
+   degSec-001-00  (4), -- B'100  1    deg/sec
+   degSec-000-10  (5), -- B'101  0.1  deg/sec
+   degSec-000-05  (6), -- B'110  0.05 deg/sec
+   degSec-000-01  (7)  -- B'111  0.01 deg/sec
+   }  
+   -- Encoded as a 3 bit value
+
+YawRate ::= INTEGER (-32767..32767) 
+   -- LSB units of 0.01 degrees per second (signed)
+
+ZoneLength ::= INTEGER (0..10000)
+    -- Unit = 1 meter, 0 = unknown, 
+    -- The value 10000 to be used for Distances >=10000 m
+    -- (e.g. from known point to another point along a 
+    -- known path, often against traffic flow direction 
+    -- when used for measuring queues)
+
+Zoom ::= INTEGER (0..15)
+   -- A zoom scale applied in units of 2^N
+   -- A value of 0 is a 1:1 zoom (no zoom)
+   -- A value of 1 is a 2:1 zoom
+   -- A value of 2 is a 4:1 zoom, etc.
+   -- The zoom value is applied to one or more offsets
+   -- increase the span or range while reducing its precision
+   -- The absence of a zoom, any offset element in a data 
+   -- frame implies a 1:1 zoom
+
+				 
+END 
+-- end of the DSRC module.
+ 
+ 
+ 
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- Start of REGION Data entries...
+-- Grouped into sets of modules
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+-- 
+-- Begin module: REGION 
+-- 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+
+REGION DEFINITIONS AUTOMATIC TAGS::= BEGIN 
+ 
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- Start of entries from table Dialogs...
+-- This table typically contains dialog and operational exchange entries.
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+
+
+--
+-- Regional data frames with no currently defined extensions
+--
+Reg-AdvisorySpeed         DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-ComputedLane          DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-EventDescription      DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-GenericLane           DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-GeographicalPath      DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-GeometricProjection   DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-IntersectionGeometry  DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-LaneAttributes        DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-MovementState         DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-NodeAttributeSetLL    DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-NodeAttributeSetXY    DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-NodeOffsetPointLL     DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-RequestorDescription  DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-RequestorType         DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-RoadSegment           DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-SignalControlZone     DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-SignalRequest         DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-SignalRequestPackage  DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-SignalStatus          DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-SignalStatusPackage   DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-SupplementalVehicleExtensions DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-VehicleClassification DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+Reg-VerticalOffset        DSRC.REG-EXT-ID-AND-TYPE ::= { ...  }
+
+--
+-- Data Frames with current adopted expansion point content
+--
+Reg-ConnectionManeuverAssist DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpC.ConnectionManeuverAssist-addGrpC IDENTIFIED BY DSRC.addGrpC} ,
+   ... 
+   }
+
+Reg-IntersectionState     DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpC.IntersectionState-addGrpC IDENTIFIED BY DSRC.addGrpC} ,
+   ... 
+   }
+
+Reg-LaneDataAttribute     DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpB.LaneDataAttribute-addGrpB IDENTIFIED BY DSRC.addGrpB} ,
+   ... 
+   }  
+
+Reg-MovementEvent         DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpB.MovementEvent-addGrpB IDENTIFIED BY DSRC.addGrpB} ,
+   ... 
+   }   
+
+Reg-NodeOffsetPointXY     DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpB.NodeOffsetPointXY-addGrpB IDENTIFIED BY DSRC.addGrpB} ,
+   ... 
+   }   
+
+Reg-Position3D            DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpB.Position3D-addGrpB IDENTIFIED BY DSRC.addGrpB} |
+   { AddGrpC.Position3D-addGrpC IDENTIFIED BY DSRC.addGrpC} ,
+   ... 
+   }   
+
+Reg-RestrictionUserType   DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpC.RestrictionUserType-addGrpC IDENTIFIED BY DSRC.addGrpC} ,
+   ... 
+   }   
+
+
+
+-- 
+-- The pattern used for regional adaptations is shown below
+-- Use:
+-- the text 'XXX' below is used to represent the name of the entry
+-- the region should replace 'xxx-RegionName' with its own Type Def
+-- a name pattern such as 'DataFrameName-RegionName' is recommended
+-- the 'regionName' value must be assigned from the RegionId element
+-- this value would be defined in the REGION module, unless a well-known 
+-- region was being used (these IDs are defined in the DSRC module)
+-- refer to the full standard for additional details
+--
+--Reg-XXX DSRC.REG-EXT-ID-AND-TYPE ::= {
+--   { XXX-RegionName IDENTIFIED BY regionName  },
+--   ... 
+--}
+--regionName DSRC.RegionId ::= 128 
+--XXX-RegionName ::= SEQUENCE { ... }
+--
+-- End example pattern for regional use
+
+
+-- Extension markers for operational messages in the standard
+-- Messages with no currently defined extensions
+Reg-BasicSafetyMessage     DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-CommonSafetyRequest    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-EmergencyVehicleAlert  DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-IntersectionCollision  DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-NMEAcorrections        DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-ProbeDataManagement    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-ProbeVehicleData       DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-RoadSideAlert          DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-RTCMcorrections        DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-SignalRequestMessage   DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-SignalStatusMessage    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-SPAT                   DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TravelerInformation    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-PersonalSafetyMessage  DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+
+-- Messages with current adopted extension marker content
+Reg-MapData                DSRC.REG-EXT-ID-AND-TYPE ::= { 
+   { AddGrpC.MapData-addGrpC IDENTIFIED BY DSRC.addGrpC},
+   ... 
+   }
+
+
+-- Test Messages
+Reg-TestMessage00    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage01    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage02    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage03    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage04    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage05    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage06    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage07    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage08    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage09    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage10    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage11    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage12    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage13    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage14    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+Reg-TestMessage15    DSRC.REG-EXT-ID-AND-TYPE ::= { ... }
+
+
+
+ 
+END
+
+ 
+ 
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- Start of External Data entries...
+-- Grouped into sets of modules
+-- -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+-- 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+-- 
+-- Begin module: AddGrpC
+-- 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+AddGrpC DEFINITIONS AUTOMATIC TAGS::= BEGIN 
+ 
+AltitudeConfidence ::= ENUMERATED {
+   alt-000-01,  -- accuracy within    0.01 meter
+   alt-000-02,  -- accuracy within    0.02 meter
+   alt-000-05,  -- accuracy within    0.05 meter
+   alt-000-10,  -- accuracy within    0.10 meter
+   alt-000-20,  -- accuracy within    0.20 meter
+   alt-000-50,  -- accuracy within    0.50 meter
+   alt-001-00,  -- accuracy within    1.00 meter
+   alt-002-00,  -- accuracy within    2.00 meter
+   alt-005-00,  -- accuracy within    5.00 meter
+   alt-010-00,  -- accuracy within   10.00 meter
+   alt-020-00,  -- accuracy within   20.00 meter
+   alt-050-00,  -- accuracy within   50.00 meter
+   alt-100-00,  -- accuracy within  100.00 meter
+   alt-200-00,  -- accuracy within  200.00 meter
+   outOfRange,  -- accuracy exceeds 200.00 meters
+   unavailable  -- unavailable
+}
+
+AltitudeValue ::= INTEGER (-100000..800001)  -- units of  0.01 meter 
+   -- Where: 
+   -- seaLevel(0), 
+   -- oneCentimeter(1), 
+   -- unavailable(800001)
+
+EmissionType ::= ENUMERATED {
+     typeA,  -- check for proper restrictions
+     typeB,  -- 
+     typeC,  -- 
+     typeD,  -- 
+     typeE,  -- 
+     ...  
+     }
+
+Altitude ::= SEQUENCE {
+   value        AltitudeValue,
+   confidence   AltitudeConfidence
+   }
+
+PrioritizationResponse ::= SEQUENCE {
+   stationID      DSRC.StationID,
+                  -- Id of requesting vehicle
+                  -- Note that the stationID has to remain unchanged 
+                  -- during the whole prioritizationprocess
+   priorState     DSRC.PrioritizationResponseStatus,
+                  -- State of prioritization request
+   signalGroup    DSRC.SignalGroupID,
+                  -- id of prioritized LaneSet, which will 
+                  -- be given free way 
+   ...  
+   }
+
+PrioritizationResponseList ::= SEQUENCE SIZE(1..10) OF PrioritizationResponse
+
+ConnectionManeuverAssist-addGrpC ::= SEQUENCE {
+    vehicleToLanePositions  VehicleToLanePositionList,
+    rsuDistanceFromAnchor   DSRC.NodeOffsetPointXY OPTIONAL
+}
+
+IntersectionState-addGrpC ::= SEQUENCE { 
+   activePrioritizations PrioritizationResponseList OPTIONAL,
+   ... }
+
+MapData-addGrpC ::= SEQUENCE { 
+   signalHeadLocations   SignalHeadLocationList OPTIONAL,
+   ... 
+   }
+
+Position3D-addGrpC ::= SEQUENCE {
+   altitude    Altitude, 
+   ...
+   }
+
+RestrictionUserType-addGrpC ::= SEQUENCE {
+   emission   EmissionType OPTIONAL,
+   ...
+   }
+
+SignalHeadLocation ::= SEQUENCE {
+   node             DSRC.NodeOffsetPointXY, -- the location
+   signalGroupID    DSRC.SignalGroupID,   
+   ...
+}
+
+SignalHeadLocationList ::= SEQUENCE (SIZE(1..20)) OF  SignalHeadLocation
+
+VehicleToLanePosition ::= SEQUENCE {
+    stationID   DSRC.StationID, 
+    laneID      DSRC.LaneID,
+    ...  
+    }
+
+VehicleToLanePositionList ::= SEQUENCE SIZE(1..5) OF VehicleToLanePosition
+
+
+
+END
+-- End of the AddGrpC module.
+ 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+-- 
+-- Begin module: AddGrpB
+-- 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+AddGrpB DEFINITIONS AUTOMATIC TAGS::= BEGIN 
+ 
+Angle ::= INTEGER (0..239)
+   -- Unsigned units of 1.5 degree, in 1 octet
+   -- the true north is 0, positive is clockwise
+   -- the values 240 to 254 shall not be sent
+   -- the value 255 (0xFF) indicates an invalid value
+
+Day ::= INTEGER (0..255) 
+   -- BCD coding of Day of Month, in 1 octet
+   -- values with nibble values between 1010 and 1111 shall not be sent
+   -- except that the value xxx (0xFF shall indicate an invalid value
+
+DayOfWeek ::= ENUMERATED {
+    unknown   (0),
+    monday    (1),
+    tuesday   (2),
+    wednesday (3),
+    thursday  (4),
+    friday    (5),
+    saturday  (6),
+    sunday    (7)
+    }
+   -- Encoding as per above, in 3 bits
+   -- the value 0x00 shall indicate an invalid value
+
+DegreesLat ::= INTEGER (-90..90)
+   -- Signed units of degrees, in 1 octets
+   -- the values  +91 to +126 shall not be sent
+   -- the values -128 to  -91 shall not be sent
+   -- the value 127 (0x7F) shall indicate an invalid value
+
+DegreesLong ::= INTEGER (-180..180) 
+   -- Signed units of degrees, in 2 octets
+   -- the values +181 to +32766 shall not be sent
+   -- the values -181 to -32768 shall not be sent
+   -- the value 32767 (0x7FFF shall indicate an invalid value
+
+Elevation ::= INTEGER (-32768..32767)  
+  -- Signed units of 0.1m (10cm), in 2 octets
+  -- the value 32767 (0x7FFF) shall indicate an invalid value
+
+Holiday ::= ENUMERATED {
+    weekday  (0),
+    holiday  (1)
+    }
+   -- Encoding as per above, in 1 bit
+
+Hour ::= INTEGER (0..255) 
+   -- BCD coding of Hour of a Day, in 1 octet
+   -- values above upper nibble 0010 and lower nibble 0100 shall not be sent
+   -- values with lower nibble values between 1010 and 1111 shall not be sent
+   -- except that the value 255 (0xFF) shall indicate an invalid value
+
+LatitudeDMS ::= INTEGER (-32400000.. 32400000) 
+   -- Signed units of 0.01 seconds of a minute of a degree of Latitude
+   -- Providing a range of plus-minus 90 degrees
+   -- in a 4 octet value when implicit or in BER forms
+   -- the value 0x7FFF FFFF shall indicate an invalid value
+
+LongitudeDMS ::= INTEGER (-64800000.. 64800000) 
+   -- Signed units of 0.01 seconds of a minute of a degree of Longitude
+   -- Providing a range of plus-minus 180 degrees
+   -- in a 4 octet value when implicit or in BER forms
+   -- the value 0x7FFF FFFF shall indicate an invalid value
+
+MaxTimetoChange ::= INTEGER (0..2402)
+   -- Unsigned units of 0.1 seconds, in 2 octets
+   -- the value 2401 shall indicate 'forever'
+   -- the values 2402 to 65534 shall not be sent
+   -- the value 65535 (0xFFFF) shall indicate an invalid value
+
+MinTimetoChange ::= INTEGER (0..2402)
+   -- Unsigned units of 0.1 seconds, in 2 octets
+   -- the value 2401 shall indicate 'forever'
+   -- the values 2402 to 32766 shall not be sent
+   -- the value 32767(0x7FFF) shall indicate an invalid value
+   -- Note that:
+   -- The MSB is used as a flag and set to one to
+   -- indicate that the value does not count down.
+   -- Under this condition the movement phase may end
+   -- immediately if certain condition are meet.
+
+Minute ::= INTEGER (0..255) 
+   -- BCD coding of Minute of an Hour, in 1 octet 
+   -- values above a combined BCD value of 59 (>59)
+   -- (i.e. 0110 0000) shall not be sent
+   -- except that value 255 (0xFF) shall indicate an invalid value
+
+MinutesAngle ::= INTEGER (0..59)   
+   -- Unsigned units of minutes of an angle, in 1 octet 
+   -- values above 59 shall not be sent
+   -- except that value 255 (0xFF) shall indicate an invalid value
+
+Month ::= INTEGER (1..255) 
+   -- BCD coding of Month of a year, in 1 octet
+   -- values above a combined BCD value of 12 (>12)
+   -- (i.e. 0001 0011) shall not be sent
+   -- except that value 255 (0xFF) shall indicate an invalid value
+
+MsgCount ::= INTEGER (0..255)
+   -- a count value which is incremented with each use
+   -- the next value after 255 shall be one
+   -- value 0 (0x00) shall indicate that MsgCount is not available
+
+Second ::= INTEGER (0..60) 
+   -- BCD coding of a second of time, in 1 octet 
+   -- values above a combined BCD value of 60
+   -- (i.e. 0110 0000) shall not be sent
+   -- except that value 255 (0xFF) shall indicate an invalid value
+
+SecondsAngle ::= INTEGER (0..5999)  
+   -- Unsigned units of 1/100th seconds of angle, in 2 octets
+   -- values from 6000 to 65534 shall not be sent
+   -- the value 65535 (0xFFFF) shall indicate an invalid value
+
+SummerTime ::= ENUMERATED {
+    notInSummerTime   (0),
+    inSummerTime      (1)
+    }
+   -- Encoding as per above, in 1 bit
+
+TenthSecond ::= INTEGER (0..9) 
+   -- Unsigned units of 100 milliseconds, in 1 octet
+   -- values from 10 to 254 shall not be sent
+   -- the value 255 (0xFF) shall indicate an invalid value
+
+TimeRemaining ::= INTEGER (0..9001)
+    -- Unsigned units of 0.1 seconds, spanning 15 minutes, in 2 octets
+    -- the value 9001 shall indicate 'forever'
+    -- values from 9002 to 65534 shall not be sent
+    -- the value 65535 (0xFFFF) shall indicate an invalid value
+
+Year ::= INTEGER (1..65535)
+   -- BCD coding of four digits of the year A.D. in 2 octets 
+   -- values with nibble values between 1010 and 1111 shall not be sent
+   -- except that the value 65535 (0xFFFF) shall indicate an invalid value
+
+LatitudeDMS2 ::= SEQUENCE {
+   d  DegreesLat,    -- units of degrees
+   m  MinutesAngle,  -- units of minutes
+   s  SecondsAngle   -- units of 1/100th seconds
+   } -- total size of 4 octets (32 bits) when implicit encoding is used
+
+LongitudeDMS2 ::= SEQUENCE {
+   d  DegreesLong,   -- units of degrees
+   m  MinutesAngle,  -- units of minutes
+   s  SecondsAngle   -- units of 1/100th seconds
+   } -- total size of 5 octets (40 bits) when implicit encoding is used
+
+Node-LLdms-48b ::= SEQUENCE {
+   lon  LongitudeDMS,
+   lat  LatitudeDMS
+   }
+
+Node-LLdms-80b ::= SEQUENCE {
+   lon  LongitudeDMS2,
+   lat  LatitudeDMS2
+   }
+
+LaneDataAttribute-addGrpB ::= SEQUENCE { ... }
+
+MovementEvent-addGrpB ::= SEQUENCE {
+   -- A set of countdown style time-to-change values
+   -- all in units of 0.1 seconds and following
+   -- the naming of the base DSRC standard
+
+   startTime   TimeRemaining   OPTIONAL,
+               -- When this phase 1st started
+   minEndTime  MinTimetoChange,
+               -- Expected shortest end time
+   maxEndTime  MaxTimetoChange OPTIONAL,
+               -- Expected longest end time
+   likelyTime  TimeRemaining   OPTIONAL,
+               -- Best predicted value based on other data             
+   confidence  DSRC.TimeIntervalConfidence   OPTIONAL,
+               -- Applies to above time element only
+   nextTime    TimeRemaining   OPTIONAL,
+   ...
+   }
+
+NodeOffsetPointXY-addGrpB ::= CHOICE {
+   -- Full position expressed in units of 0.01 seconds
+   posA    Node-LLdms-48b,
+
+   -- Full position expressed in multiple elements in
+   -- an DD.MM.SS.sss style format
+   posB    Node-LLdms-80b,
+
+   ...
+   }
+
+Position3D-addGrpB ::= SEQUENCE {
+   latitude     LatitudeDMS2,
+   longitude    LongitudeDMS2,
+   elevation    Elevation,
+   ...
+   }
+
+TimeMark ::= SEQUENCE {
+    year        Year,         -- BCD coding of A.D.    2 octets
+    month       Month,        -- BCD coding of Month,  1 octet
+    day         Day,          -- BCD coding of Day,    1 octet
+    summerTime  SummerTime,
+    holiday     Holiday,
+    dayofWeek   DayOfWeek,
+    hour        Hour,         -- BCD coding of Hour,   1 octet
+    minute      Minute,       -- BCD coding of Minute, 1 octet
+    second      Second,       -- BCD coding of Second, 1 octet
+    tenthSecond TenthSecond   -- units of 100 millisecond, 1 octet
+}
+
+
+END
+-- End of the AddGrpB module.
+ 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+-- 
+-- Begin module: NTCIP
+-- 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+NTCIP DEFINITIONS AUTOMATIC TAGS::= BEGIN 
+ 
+EssMobileFriction ::= INTEGER (0..101)
+
+EssPrecipRate ::= INTEGER (0..65535) 
+
+EssPrecipSituation ::= ENUMERATED {
+   other (1), 
+   unknown (2), 
+   noPrecipitation (3), 
+   unidentifiedSlight (4), 
+   unidentifiedModerate (5), 
+   unidentifiedHeavy (6), 
+   snowSlight (7), 
+   snowModerate (8), 
+   snowHeavy (9), 
+   rainSlight (10), 
+   rainModerate (11), 
+   rainHeavy (12), 
+   frozenPrecipitationSlight (13), 
+   frozenPrecipitationModerate (14), 
+   frozenPrecipitationHeavy (15)
+   }
+
+EssPrecipYesNo ::= ENUMERATED {precip (1), noPrecip (2), error (3)} 
+
+EssSolarRadiation ::= INTEGER (0..65535) 
+
+
+ 
+END
+-- End of the NTCIP module.
+ 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+-- 
+-- Begin module: ITIS
+-- 
+-- ^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-^-
+ITIS DEFINITIONS AUTOMATIC TAGS::= BEGIN 
+ 
+GenericLocations ::= ENUMERATED  { 
+   -- Road Related
+   on-bridges                  (7937),  -- Not to be used as the default for this
+                                        -- category
+   in-tunnels                  (7938),  
+   entering-or-leaving-tunnels (7939),  
+   on-ramps                    (7940),  
+   in-road-construction-area   (7941),  
+   around-a-curve              (7942),  
+   on-curve                    (8026),   
+   on-tracks                   (8009),   
+   in-street                   (8025),  -- As in in-street pad crossing
+   shoulder                    (8027),   
+   on-minor-roads              (7943),  
+   in-the-opposing-lanes       (7944),  
+   adjacent-to-roadway         (7945),  
+   across-tracks               (8024),   
+   on-bend                     (7946),  
+   intersection                (8032),   
+   entire-intersection         (7947),  
+   in-the-median               (7948),  
+   moved-to-side-of-road       (7949),  
+   moved-to-shoulder           (7950),  
+   on-the-roadway              (7951),  -- Use generic locations/groups affected to
+                                        -- make other such phrases
+   dip                         (8010),   
+   traffic-circle              (8011),  -- Used for W2-6 graphic as well. Alt term:
+                                        -- roundabout
+   crossover                   (8028),  
+   cross-road                  (8029),  -- Also used for W2-1 Note that in some uses
+                                        -- this is one word
+   side-road                   (8030),  -- Do not used for W2-2R and W2-2L
+   to                          (8014),   
+   by                          (8015),   
+   through                     (8016),   
+   area-of                     (8017),  -- Also area
+   under                       (8018),     
+   over                        (8019),   
+   from                        (8020),   
+   approaching                 (8021),   
+   entering-at                 (8022),  -- Alt form: Entrance
+   exiting-at                  (8023),  
+   -- Terrain & Geography
+   in-shaded-areas             (7952),  
+   in-low-lying-areas          (7953),  
+   in-the-downtown-area        (7954),  
+   in-the-inner-city-area      (7955),  
+   in-parts                    (7956),  
+   in-some-places              (7957),  
+   in-the-ditch                (7958),  
+   in-the-valley               (7959),  
+   on-hill-top                 (7960),  
+   near-the-foothills          (7961),  
+   at-high-altitudes           (7962),  
+   near-the-lake               (7963),  
+   near-the-shore              (7964),  
+   nearby-basin                (8008),  
+   over-the-crest-of-a-hill    (7965),  
+   other-than-on-the-roadway   (7966),  
+   near-the-beach              (7967),  
+   near-beach-access-point     (7968),  
+   mountain-pass               (8006),  
+   lower-level                 (7969),  
+   upper-level                 (7970),  
+   -- Transit Travel, Air Travel and Places
+   airport                     (7971),  
+   concourse                   (7972),  
+   gate                        (7973),  
+   baggage-claim               (7974),  
+   customs-point               (7975),  
+   reservation-center          (8007),  
+   station                     (7976),  
+   platform                    (7977),  -- Alternative Rendering:  track
+   dock                        (7978),  
+   depot                       (7979),  
+   ev-charging-point           (7980),  
+   information-welcome-point   (7981),  -- Use for Tourist Information as well (D9-10)
+   at-rest-area                (7982),  
+   at-service-area             (7983),  
+   at-weigh-station            (7984),  
+   roadside-park               (8033),  
+   picnic-areas                (7985),  
+   rest-area                   (7986),  
+   service-stations            (7987),  
+   toilets                     (7988),  -- Note also rest rooms in structures
+   bus-stop                    (8031),  
+   park-and-ride-lot           (8012),  -- Not to be used as a mode of travel
+   -- Direction of Travel
+   on-the-right                (7989),  
+   on-the-left                 (7990),  
+   in-the-center               (7991),  
+   in-the-opposite-direction   (7992),  
+   cross-traffic               (7993),  
+   northbound-traffic          (7994),  
+   eastbound-traffic           (7995),  
+   southbound-traffic          (7996),  
+   westbound-traffic           (7997),  
+   -- Compass Points
+   north                       (7998),  
+   south                       (7999),  
+   east                        (8000),  
+   west                        (8001),  
+   northeast                   (8002),  
+   northwest                   (8003),  
+   southeast                   (8004),  
+   southwest                   (8005),  
+   ... -- # LOCAL_CONTENT_ITIS 
+   }
+
+
+IncidentResponseEquipment ::= ENUMERATED { 
+   ground-fire-suppression          (9985),   
+   heavy-ground-equipment           (9986),   
+   aircraft                         (9988),   
+   marine-equipment                 (9989),   
+   support-equipment                (9990),   
+   medical-rescue-unit              (9991),   
+   other                            (9993),   -- Depreciated by fire standards, do not
+                                              -- use
+   ground-fire-suppression-other    (9994),   
+   engine                           (9995),   
+   truck-or-aerial                  (9996),   
+   quint                            (9997),   -- A five-function type of fire 
+                                              -- apparatus. The units in the 
+                                              -- movie Backdraft were quints
+   tanker-pumper-combination        (9998),   
+   brush-truck                      (10000),  
+   aircraft-rescue-firefighting     (10001),  
+   heavy-ground-equipment-other     (10004),  
+   dozer-or-plow                    (10005),  
+   tractor                          (10006),  
+   tanker-or-tender                 (10008),  
+   aircraft-other                   (10024),  
+   aircraft-fixed-wing-tanker       (10025),  
+   helitanker                       (10026),  
+   helicopter                       (10027),  
+   marine-equipment-other           (10034),  
+   fire-boat-with-pump              (10035),  
+   boat-no-pump                     (10036),  
+   support-apparatus-other          (10044),  
+   breathing-apparatus-support      (10045),  
+   light-and-air-unit               (10046),  
+   medical-rescue-unit-other        (10054),  
+   rescue-unit                      (10055),  
+   urban-search-rescue-unit         (10056),  
+   high-angle-rescue                (10057),  
+   crash-fire-rescue                (10058),  
+   bLS-unit                         (10059),  
+   aLS-unit                         (10060),  
+   mobile-command-post              (10075),  -- Depreciated, do not use
+   chief-officer-car                (10076),  
+   hAZMAT-unit                      (10077),  
+   type-i-hand-crew                 (10078),  
+   type-ii-hand-crew                (10079),  
+   privately-owned-vehicle          (10083),  -- (Often found in volunteer fire teams)
+   other-apparatus-resource         (10084),  -- (Remapped from fire code zero)
+   ambulance                        (10085),  
+   bomb-squad-van                   (10086),  
+   combine-harvester                (10087),  
+   construction-vehicle             (10088),  
+   farm-tractor                     (10089),  
+   grass-cutting-machines           (10090),  
+   hAZMAT-containment-tow           (10091),  
+   heavy-tow                        (10092),  
+   light-tow                        (10094),  
+   flatbed-tow                      (10114), 
+   hedge-cutting-machines           (10093),  
+   mobile-crane                     (10095),  
+   refuse-collection-vehicle        (10096),  
+   resurfacing-vehicle              (10097),  
+   road-sweeper                     (10098),  
+   roadside-litter-collection-crews (10099),  
+   salvage-vehicle                  (10100),  
+   sand-truck                       (10101),  
+   snowplow                         (10102),  
+   steam-roller                     (10103),  
+   swat-team-van                    (10104),  
+   track-laying-vehicle             (10105),  
+   unknown-vehicle                  (10106),  
+   white-lining-vehicle             (10107),  -- Consider using Roadwork "road marking
+                                              -- operations" unless objective is to
+                                              -- refer to the specific vehicle of this
+                                              -- type.  Alternative Rendering: line
+                                              -- painting vehicle
+   dump-truck                       (10108),  
+   supervisor-vehicle               (10109),  
+   snow-blower                      (10110),  
+   rotary-snow-blower               (10111),  
+   road-grader                      (10112),  -- Alternative term: motor grader
+   steam-truck                      (10113),  -- A special truck that thaws culverts 
+                                              -- and storm drains
+   ... -- # LOCAL_CONTENT_ITIS 
+   }
+
+ITIStext ::= IA5String (SIZE(1..500))
+
+ResponderGroupAffected ::= ENUMERATED { 
+   emergency-vehicle-units           (9729),  -- Default, to be used when one of
+                                              -- the below does not fit better
+   federal-law-enforcement-units     (9730),  
+   state-police-units                (9731),  
+   county-police-units               (9732),  -- Hint: also sheriff response units
+   local-police-units                (9733),  
+   ambulance-units                   (9734),  
+   rescue-units                      (9735),  
+   fire-units                        (9736),  
+   hAZMAT-units                      (9737),  
+   light-tow-unit                    (9738),  
+   heavy-tow-unit                    (9739),  
+   freeway-service-patrols           (9740),  
+   transportation-response-units     (9741),  
+   private-contractor-response-units (9742),  
+   ... -- # LOCAL_CONTENT_ITIS 
+   }
+   -- These groups are used in coordinated response and staging area information
+   -- (rather than typically consumer related)
+
+VehicleGroupAffected ::= ENUMERATED { 
+   all-vehicles                               (9217),  
+   bicycles                                   (9218),  
+   motorcycles                                (9219),  -- to include mopeds as well
+   cars                                       (9220),  -- (remapped from ERM value of
+                                                       -- zero)
+   light-vehicles                             (9221),  
+   cars-and-light-vehicles                    (9222),  
+   cars-with-trailers                         (9223),  
+   cars-with-recreational-trailers            (9224),  
+   vehicles-with-trailers                     (9225),  
+   heavy-vehicles                             (9226),  
+   trucks                                     (9227),  
+   buses                                      (9228),  
+   articulated-buses                          (9229),  
+   school-buses                               (9230),  
+   vehicles-with-semi-trailers                (9231),  
+   vehicles-with-double-trailers              (9232),  -- Alternative Rendering:  
+                                                       -- western doubles
+   high-profile-vehicles                      (9233),  
+   wide-vehicles                              (9234),  
+   long-vehicles                              (9235),  
+   hazardous-loads                            (9236),  
+   exceptional-loads                          (9237),  
+   abnormal-loads                             (9238),  
+   convoys                                    (9239),  
+   maintenance-vehicles                       (9240),  
+   delivery-vehicles                          (9241),  
+   vehicles-with-even-numbered-license-plates (9242),  
+   vehicles-with-odd-numbered-license-plates  (9243),  
+   vehicles-with-parking-permits              (9244),  
+   vehicles-with-catalytic-converters         (9245),  
+   vehicles-without-catalytic-converters      (9246),  
+   gas-powered-vehicles                       (9247),  
+   diesel-powered-vehicles                    (9248),  
+   lPG-vehicles                               (9249),  -- The L is lower case here
+   military-convoys                           (9250),  
+   military-vehicles                          (9251),  
+   ... -- # LOCAL_CONTENT_ITIS 
+   }
+   -- Classification of vehicles and types of transport
+
+ITIScodesAndText ::= SEQUENCE (SIZE(1..100)) OF SEQUENCE {
+  item CHOICE    {
+       itis ITIScodes,
+       text ITIStext
+       } -- # UNTAGGED
+  }
+
+ITIScodes ::= INTEGER (0..65535)
+-- The defined list of ITIS codes is too long to list here
+-- Many smaller lists use a sub-set of these codes as defined elements
+-- Also enumerated values expressed as text constant are very common,
+-- and in many deployments the list codes are used as a shorthand for
+-- this text.  Also the XML expressions commonly use a union of the 
+-- code values and the textual expressions.  
+-- Consult SAE J2540 for further details.
+
+ 
+END
+-- End of the ITIS module.
+ 
+ 
+
+
+-- End of file output at 9/1/2015 7:29:03 PM
+-- Edits by hand to reflect r21 draft, 
+-- Completed Oct 30 2015 at 18:37 UTC time
+-- Updated March 8th 2016 to correct minor changes in J2735. 


### PR DESCRIPTION
Now that the J2735 ASN is now free and allowed to be redistributed, it is being included as a part of this repository. This will make building the repository possible after cloning it and its submodules as well as the potential for an updated docker hub build.

https://www.sae.org/standards/content/j2735asn_201603/