### PR TITLE
Logging Level Standardization and ACM Enhancements

### DIFF
--- a/docker-compose-confluent-cloud.yml
+++ b/docker-compose-confluent-cloud.yml
@@ -13,6 +13,7 @@ services:
       ACM_LOG_LEVEL: ${ACM_LOG_LEVEL}
       CONFLUENT_KEY: ${CONFLUENT_KEY}
       CONFLUENT_SECRET: ${CONFLUENT_SECRET}
+    restart: on-failure
   aem:
     build:
       context: .
@@ -26,3 +27,4 @@ services:
       ACM_LOG_LEVEL: ${ACM_LOG_LEVEL}
       CONFLUENT_KEY: ${CONFLUENT_KEY}
       CONFLUENT_SECRET: ${CONFLUENT_SECRET}
+    restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,3 +32,4 @@ services:
       ACM_LOG_TO_CONSOLE: "${ACM_LOG_TO_CONSOLE}"
       ACM_LOG_TO_FILE: "${ACM_LOG_TO_FILE}"
       ACM_LOG_LEVEL: "${ACM_LOG_LEVEL}"
+    restart: on-failure

--- a/include/acmLogger.hpp
+++ b/include/acmLogger.hpp
@@ -29,7 +29,7 @@ class AcmLogger {
         long LOG_SIZE = 1048576 * 5;                   ///> The size of a single log; these rotate.
         int LOG_NUM = 5;                               ///> The number of logs to rotate.
     
-        spdlog::level::level_enum loglevel = spdlog::level::trace;     ///> Log level for the logger.
+        spdlog::level::level_enum loglevel = spdlog::level::err;     ///> Log level for the logger.
         
         std::shared_ptr<spdlog::logger> spdlogger;     ///> The spdlog logger.
 

--- a/sample.env
+++ b/sample.env
@@ -8,5 +8,5 @@ ACM_LOG_TO_CONSOLE=
 ACM_LOG_TO_FILE=
 
 # The log level to use.
-# Valid values are: "debug", "info", "warning", "error", "critical", "off"
+# Valid values are: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "off"
 ACM_LOG_LEVEL=

--- a/sample.env
+++ b/sample.env
@@ -8,5 +8,5 @@ ACM_LOG_TO_CONSOLE=
 ACM_LOG_TO_FILE=
 
 # The log level to use.
-# Valid values are: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "off"
+# Valid values are: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "OFF"
 ACM_LOG_LEVEL=

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -430,19 +430,19 @@ bool ASN1_Codec::configure() {
     } 
     
     if (optIsSet('v')) {
-        if ("trace" == optString('v')) {
+        if ("TRACE" == optString('v')) {
             logger->set_level(spdlog::level::trace);
-        } else if ("debug" == optString('v')) {
+        } else if ("DEBUG" == optString('v')) {
             logger->set_level(spdlog::level::trace);
-        } else if ("info" == optString('v')) {
+        } else if ("INFO" == optString('v')) {
             logger->set_level(spdlog::level::trace);
-        } else if ("warning" == optString('v')) {
+        } else if ("WARNING" == optString('v')) {
             logger->set_level(spdlog::level::warn);
-        } else if ("error" == optString('v')) {
+        } else if ("ERROR" == optString('v')) {
             logger->set_level(spdlog::level::err);
-        } else if ("critical" == optString('v')) {
+        } else if ("CRITICAL" == optString('v')) {
             logger->set_level(spdlog::level::critical);
-        } else if ("off" == optString('v')) {
+        } else if ("OFF" == optString('v')) {
             logger->set_level(spdlog::level::off);
         } else {
             logger->warn("information logger level was configured but unreadable; using default.");

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -309,11 +309,11 @@ bool ASN1_Codec::topic_available( const std::string& topic ) {
 
     } else if ( err == RdKafka::ERR__TRANSPORT) {
         logger->error("cannot retrieve consumer metadata: Broker Transport Failure ");
-        logger->error("Container Exiting...will try restarting");
+        logger->error("Container Exiting...");
         std::exit(EXIT_FAILURE);
     } else {
         logger->error("cannot retrieve consumer metadata with error: " + err2str(err));
-        logger->error("Container Exiting...will try restarting");
+        logger->error("Container Exiting...");
         std::exit(EXIT_FAILURE);
     }
 

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -290,7 +290,6 @@ bool ASN1_Codec::topic_available( const std::string& topic ) {
 
     RdKafka::Metadata* md; // must be freed if allocated
     RdKafka::ErrorCode err = consumer_ptr->metadata( true, nullptr, &md, 5000 );
-    // TODO: Will throw a broker transport error (ERR__TRANSPORT = -195) if the broker is not available.
 
     if ( err == RdKafka::ERR_NO_ERROR ) {
         RdKafka::Metadata::TopicMetadataIterator it = md->topics()->begin();
@@ -308,8 +307,14 @@ bool ASN1_Codec::topic_available( const std::string& topic ) {
             logger->warn("Metadata did not contain topic: " + topic);
         }
 
+    } else if ( err == RdKafka::ERR__TRANSPORT) {
+        logger->error("cannot retrieve consumer metadata: Broker Transport Failure ");
+        logger->error("Container Exiting...will try restarting");
+        std::exit(EXIT_FAILURE);
     } else {
         logger->error("cannot retrieve consumer metadata with error: " + err2str(err));
+        logger->error("Container Exiting...will try restarting");
+        std::exit(EXIT_FAILURE);
     }
 
     if (md) {

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -433,9 +433,9 @@ bool ASN1_Codec::configure() {
         if ("TRACE" == optString('v')) {
             logger->set_level(spdlog::level::trace);
         } else if ("DEBUG" == optString('v')) {
-            logger->set_level(spdlog::level::trace);
+            logger->set_level(spdlog::level::debug);
         } else if ("INFO" == optString('v')) {
-            logger->set_level(spdlog::level::trace);
+            logger->set_level(spdlog::level::info);
         } else if ("WARNING" == optString('v')) {
             logger->set_level(spdlog::level::warn);
         } else if ("ERROR" == optString('v')) {

--- a/src/acm_blob_producer.cpp
+++ b/src/acm_blob_producer.cpp
@@ -188,19 +188,19 @@ JMC: TODO: All the ASN1C variables that are normally setup do here!
 bool ACMBlobProducer::configure() {
 
     if ( optIsSet('v') ) {
-        if ( "trace" == optString('v') ) {
+        if ( "TRACE" == optString('v') ) {
             logger->set_level( spdlog::level::trace );
-        } else if ( "debug" == optString('v') ) {
+        } else if ( "DEBUG" == optString('v') ) {
             logger->set_level( spdlog::level::trace );
-        } else if ( "info" == optString('v') ) {
+        } else if ( "INFO" == optString('v') ) {
             logger->set_level( spdlog::level::trace );
-        } else if ( "warning" == optString('v') ) {
+        } else if ( "WARNING" == optString('v') ) {
             logger->set_level( spdlog::level::warn );
-        } else if ( "error" == optString('v') ) {
+        } else if ( "ERROR" == optString('v') ) {
             logger->set_level( spdlog::level::err );
-        } else if ( "critical" == optString('v') ) {
+        } else if ( "CRITICAL" == optString('v') ) {
             logger->set_level( spdlog::level::critical );
-        } else if ( "off" == optString('v') ) {
+        } else if ( "OFF" == optString('v') ) {
             logger->set_level( spdlog::level::off );
         } else {
             logger->warn("information logger level was configured but unreadable; using default.");

--- a/src/acm_blob_producer.cpp
+++ b/src/acm_blob_producer.cpp
@@ -191,9 +191,9 @@ bool ACMBlobProducer::configure() {
         if ( "TRACE" == optString('v') ) {
             logger->set_level( spdlog::level::trace );
         } else if ( "DEBUG" == optString('v') ) {
-            logger->set_level( spdlog::level::trace );
+            logger->set_level( spdlog::level::debug );
         } else if ( "INFO" == optString('v') ) {
-            logger->set_level( spdlog::level::trace );
+            logger->set_level( spdlog::level::info );
         } else if ( "WARNING" == optString('v') ) {
             logger->set_level( spdlog::level::warn );
         } else if ( "ERROR" == optString('v') ) {


### PR DESCRIPTION
The logging level strings have been converted to uppercase to match those in other submodules.

Other updates include:
- Docker-compose.yml files have been modified to automatically restart in case of failure.
- The default logging level has been changed from TRACE to ERROR.
- ACM will now gracefully shut down when it encounters a transport error or an unrecognized Kafka error.