### PR TITLE
Added info on breaking changes to release notes for 2.0.0

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -19,6 +19,9 @@ Known Issues:
 - The do_kafka_test.sh script in the project's root directory is currently not running successfully. The issue is being investigated and will be addressed in a future update.
 - According to Valgrind, a minor memory leak has been detected. The development team is aware of this and is actively working on resolving it.
 
+Breaking Changes
+- Users should note that due to the switch to J2735 2020, TIMs conforming to J2735 2016 will no longer be encoded/decoded correctly. This is due to the fact that the J2735 2020 standard has renamed some fields for TIMs. Users should ensure that their TIMs are updated to conform to the J2735 2020 standard.
+
 
 Version 1.5.0, released November 2023
 ----------------------------------------

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -20,7 +20,12 @@ Known Issues:
 - According to Valgrind, a minor memory leak has been detected. The development team is aware of this and is actively working on resolving it.
 
 Breaking Changes
-- Users should note that due to the switch to J2735 2020, TIMs conforming to J2735 2016 will no longer be processed successfully. This is due to the fact that the J2735 2020 standard has renamed some fields for TIMs. The corresponding updates in the 1.6.0 update for the ODE handles these changes for incoming 2016 TIMs, but any outside applications will need to update their systems to handle these changes prior to forwarding 2016 TIMs to the ACM.
+- Users should note that due to the switch to J2735 2020, TIMs conforming to J2735 2016 will no longer be processed successfully. This is due to the fact that the J2735 2020 standard has renamed some fields for TIMs. The corresponding updates in the 1.6.0 update for the ODE handles these changes for incoming 2016 TIMs, but any outside applications will need to update their systems to handle these changes prior to forwarding 2016 TIMs to the ACM. The TIM changes in J2735 2020 include the following field renamings:
+    - `sspTimRights` -> `notUsed`
+    - `sspLocationRights` -> `notUsed1`
+    - `sspMsgRights1` -> `notUsed2`
+    - `sspMsgRights2` -> `notUsed3`
+    - `duratonTime` -> `durationTime`
 
 
 Version 1.5.0, released November 2023

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -20,7 +20,7 @@ Known Issues:
 - According to Valgrind, a minor memory leak has been detected. The development team is aware of this and is actively working on resolving it.
 
 Breaking Changes
-- Users should note that due to the switch to J2735 2020, TIMs conforming to J2735 2016 will no longer be processed successfully. This is due to the fact that the J2735 2020 standard has renamed some fields for TIMs. The corresponding updates in the 1.6.0 update for the ODE handles these changes for incoming 2016 TIMs, but any outside applications will need to update their systems to handle these changes prior to forwarding 2016 TIMs to the ACM. The TIM changes in J2735 2020 include the following field renamings:
+- Users should note that due to the switch to J2735 2020, TIMs conforming to J2735 2016 will no longer be processed successfully. This is due to the fact that the J2735 2020 standard has renamed some fields for TIMs. The corresponding updates in the 2.0.0 release for the ODE handles these changes for incoming 2016 TIMs, but any outside applications will need to update their systems to handle these changes prior to forwarding 2016 TIMs to the ACM. The TIM changes in J2735 2020 include the following field renamings:
     - `sspTimRights` -> `notUsed`
     - `sspLocationRights` -> `notUsed1`
     - `sspMsgRights1` -> `notUsed2`

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -20,7 +20,7 @@ Known Issues:
 - According to Valgrind, a minor memory leak has been detected. The development team is aware of this and is actively working on resolving it.
 
 Breaking Changes
-- Users should note that due to the switch to J2735 2020, TIMs conforming to J2735 2016 will no longer be encoded/decoded correctly. This is due to the fact that the J2735 2020 standard has renamed some fields for TIMs. Users should ensure that their TIMs are updated to conform to the J2735 2020 standard.
+- Users should note that due to the switch to J2735 2020, TIMs conforming to J2735 2016 will no longer be processed successfully. This is due to the fact that the J2735 2020 standard has renamed some fields for TIMs. The corresponding updates in the 1.6.0 update for the ODE handles these changes for incoming 2016 TIMs, but any outside applications will need to update their systems to handle these changes prior to forwarding 2016 TIMs to the ACM.
 
 
 Version 1.5.0, released November 2023


### PR DESCRIPTION
## Problem
The switch to J2735 2020 means that 2016 TIMs will no longer be processed successfully by the ACM. There is no mention of this in the release notes.

## Solution
Information on breaking changes has been added to the release notes.