### PR TITLE
Updated version to 2.0.0-SNAPSHOT

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,11 +1,11 @@
 asn1_codec Release Notes
 ----------------------------
 
-Version 1.6.0, released February 2024
+Version 2.0.0, released February 2024
 ----------------------------------------
 
 ### **Summary**
-The changes for the asn1_codec 1.6.0 release include dockerfile optimizations, a transition to J2735 2020, dockerhub image documentation, a move to including the generated header/implementation files in tracked files as tarballs and updated SCMS files.
+The changes for the asn1_codec 2.0.0 release include dockerfile optimizations, a transition to J2735 2020, dockerhub image documentation, a move to including the generated header/implementation files in tracked files as tarballs and updated SCMS files.
 
 Enhancements in this release:
 - CDOT PR 14: Optimized dockerfiles for smaller & faster deployments by switching over to using alpine as the base image


### PR DESCRIPTION
## Problem
Since there are some breaking changes for this upcoming release, the rules of semantic versioning state that the major version should be updated.

## Solution
The latest version in the release notes has been updated to 2.0.0-SNAPSHOT.