### PR TITLE
Update GitHub Actions Third-Party Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       options: "--user root"
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         # Checkout the code from the repository
 
       - name: Install necessary dependencies
@@ -84,7 +84,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v3
         # Install SonarScanner and build-wrapper for code analysis
 
       - name: Build and Generate test coverage
@@ -101,20 +101,20 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: asn1-codec
           path: /__w/asn1-codec/asn1-codec/coverage/
         # Archive code coverage results for later reference
 
       - name: Archive buildwrapper output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: asn1-codec
           path: /home/runner/work/asn1-codec/asn1-codec/bw-output
         # Archive build-wrapper output
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
         run: echo "TAG=$(echo ${GITHUB_REF##*/} | sed 's/\//-/g')" >> $GITHUB_ENV
 
       - name: Build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: usdotjpoode/asn1_codec:${{ env.TAG }}


### PR DESCRIPTION
Update GitHub Actions workflows with latest version of third party actions from external repositories to remove Node.js and other deprecation warnings.